### PR TITLE
Add support for domains in smb:// URLs

### DIFF
--- a/python2/smb/SMBHandler.py
+++ b/python2/smb/SMBHandler.py
@@ -36,6 +36,11 @@ class SMBHandler(urllib2.BaseHandler):
             passwd = None
         host = unquote(host)
         user = user or ''
+
+        domain = ''
+        if ';' in user:
+            domain, user = user.split(';', 1)
+
         passwd = passwd or ''
         myname = MACHINE_NAME or self.generateClientMachineName()
 
@@ -54,7 +59,7 @@ class SMBHandler(urllib2.BaseHandler):
         service, path = dirs[0], '/'.join(dirs[1:])
 
         try:
-            conn = SMBConnection(user, passwd, myname, server_name, use_ntlm_v2 = USE_NTLM)
+            conn = SMBConnection(user, passwd, myname, server_name, domain=domain, use_ntlm_v2 = USE_NTLM)
             conn.connect(host, port)
 
             if req.has_data():

--- a/python3/smb/SMBHandler.py
+++ b/python3/smb/SMBHandler.py
@@ -34,6 +34,11 @@ class SMBHandler(urllib.request.BaseHandler):
             passwd = None
         host = unquote(host)
         user = user or ''
+
+        domain = ''
+        if ';' in user:
+            domain, user = user.split(';', 1)
+
         passwd = passwd or ''
         myname = MACHINE_NAME or self.generateClientMachineName()
 
@@ -52,7 +57,7 @@ class SMBHandler(urllib.request.BaseHandler):
         service, path = dirs[0], '/'.join(dirs[1:])
 
         try:
-            conn = SMBConnection(user, passwd, myname, server_name, use_ntlm_v2 = USE_NTLM)
+            conn = SMBConnection(user, passwd, myname, server_name, domain=domain, use_ntlm_v2 = USE_NTLM)
             conn.connect(host, port)
 
             headers = email.message.Message()


### PR DESCRIPTION
Hi,

We've been using pysmb to validate SMB locations and credentials as part of the installer for a virtual appliance. One thing that we found to be missing was support for domains in smb:// URLs, so I've added that functionality.

Regards,
Andy
