### PR TITLE
Add support for unicode characters in domain, username and password

### DIFF
--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -29,6 +29,12 @@ class SMBTimeout(Exception):
     pass
 
 
+def _convert_to_unicode(string):
+    if not isinstance(string, unicode):
+        string = unicode(string, "utf-8")
+    return string
+
+
 class SMB(NMBSession):
     """
     This class represents a "connection" to the remote SMB/CIFS server.
@@ -52,9 +58,9 @@ class SMB(NMBSession):
 
     def __init__(self, username, password, my_name, remote_name, domain = '', use_ntlm_v2 = True, sign_options = SIGN_WHEN_REQUIRED, is_direct_tcp = False):
         NMBSession.__init__(self, my_name, remote_name, is_direct_tcp = is_direct_tcp)
-        self.username = username
-        self.password = password
-        self.domain = domain
+        self.username = _convert_to_unicode(username)
+        self.password = _convert_to_unicode(password)
+        self.domain = _convert_to_unicode(domain)
         self.sign_options = sign_options
         self.is_direct_tcp = is_direct_tcp
         self.use_ntlm_v2 = use_ntlm_v2 #: Similar to LMAuthenticationPolicy and NTAuthenticationPolicy as described in [MS-CIFS] 3.2.1.1


### PR DESCRIPTION
Hi Mike,

I recently ran into unicode-related issues when logging usernames containing Japanese characters in the python2 version of `smb.base.SMB.__init__()` . This patch fixes the issue.

For our tests we used username `ユーザ名` and password `パスワード`. These were utf8-encoded into byte strings, and then url-encoded using urllib2.quote() to create the smb URL `smb://%E3%83%A6%E3%83%BC%E3%82%B6%E5%90%8D:%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89@<windows-server>:139`

Regards,
Andy
