### PR TITLE
Raise exceptions on connection issues

### DIFF
--- a/python2/smb/SMBConnection.py
+++ b/python2/smb/SMBConnection.py
@@ -302,7 +302,7 @@ class SMBConnection(SMB):
         return results[0]
     
     def storeFile(self, service_name, path, file_obj, timeout = 30):
-        self.storeFileFromOffset(service_name, path, file_obj, timeout)
+        self.storeFileFromOffset(service_name, path, file_obj, 0L, timeout)
 
     def storeFileFromOffset(self, service_name, path, file_obj, offset = 0L, timeout = 30):
         """

--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -302,7 +302,7 @@ class SMBConnection(SMB):
         return results[0]
     
     def storeFile(self, service_name, path, file_obj, timeout = 30):
-        self.storeFileFromOffset(service_name, path, file_obj, timeout)
+        self.storeFileFromOffset(service_name, path, file_obj, 0L, timeout)
 
     def storeFileFromOffset(self, service_name, path, file_obj, offset = 0, timeout = 30):    
         """


### PR DESCRIPTION
Use socket.connect() instead of connect_ex(), so the error is raised if
the port is incorrect since it is currently being lost.  This change
will raise socket.error with errno.ECONNREFUSED during the connect
instead of errno.EPIPE during a send.
