### PR TITLE
Raise exceptions on connection issues

### DIFF
--- a/python2/smb/SMBConnection.py
+++ b/python2/smb/SMBConnection.py
@@ -99,7 +99,7 @@ class SMBConnection(SMB):
 
         self.auth_result = None
         self.sock = socket.socket(sock_family)
-        self.sock.connect_ex(( ip, port ))
+        self.sock.connect(( ip, port ))
 
         self.is_busy = True
         try:

--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -99,7 +99,7 @@ class SMBConnection(SMB):
 
         self.auth_result = None
         self.sock = socket.socket(sock_family)
-        self.sock.connect_ex(( ip, port ))
+        self.sock.connect(( ip, port ))
 
         self.is_busy = True
         try:


### PR DESCRIPTION
Use socket.connect() instead of connect_ex(), so the error is raised if
the port is incorrect since it is currently being lost.  This change
will raise socket.error with errno.ECONNREFUSED during the connect
instead of errno.EPIPE during a send.
