### PR TITLE
Pass zero offset to storeFileFromOffset

### DIFF
--- a/python2/smb/SMBConnection.py
+++ b/python2/smb/SMBConnection.py
@@ -302,7 +302,7 @@ class SMBConnection(SMB):
         return results[0]
     
     def storeFile(self, service_name, path, file_obj, timeout = 30):
-        self.storeFileFromOffset(service_name, path, file_obj, timeout)
+        self.storeFileFromOffset(service_name, path, file_obj, 0L, timeout)
 
     def storeFileFromOffset(self, service_name, path, file_obj, offset = 0L, timeout = 30):
         """

--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -302,7 +302,7 @@ class SMBConnection(SMB):
         return results[0]
     
     def storeFile(self, service_name, path, file_obj, timeout = 30):
-        self.storeFileFromOffset(service_name, path, file_obj, timeout)
+        self.storeFileFromOffset(service_name, path, file_obj, 0L, timeout)
 
     def storeFileFromOffset(self, service_name, path, file_obj, offset = 0, timeout = 30):    
         """


### PR DESCRIPTION
SMBConnection.storeFile() calls storeFileFromOffset() following commit
e381b0e743acd416509171cc4417c6ac23a2f472.  However, the commit did not
include passing a zero offset, so the timeout was being passed as the
offset.
