### PR TITLE
Remove unicode

### DIFF
--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -694,7 +694,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 p = create_message.payload
                 info = SharedFile(p.create_time, p.lastaccess_time, p.lastwrite_time, p.change_time,
                                   p.file_size, p.allocation_size, p.file_attributes,
-                                  str(path), str(path))
+                                  path, path)
                 closeFid(create_message.tid, p.fid, info = info)
             else:
                 errback(OperationFailure('Failed to get attributes for %s on %s: Unable to open remote file object' % ( path, service_name ), messages_history))
@@ -1980,7 +1980,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 file_attributes, _, alloc_size, file_size = struct.unpack(info_format, query_message.payload.data_bytes[:info_size])
 
                 info = SharedFile(create_time, last_access_time, last_write_time, last_attr_change_time,
-                                  file_size, alloc_size, file_attributes, str(path), str(path))
+                                  file_size, alloc_size, file_attributes, path, path)
                 callback(info)
             else:
                 errback(OperationFailure('Failed to get attributes for %s on %s: Read failed' % ( path, service_name ), messages_history))


### PR DESCRIPTION
I updated this to remove the unicode() function and just use simple strings.

Again, unable to test, but it works with my 3.4 project where it was failing before.
