### PR TITLE
Add function resetFileAttributes for clearing file/folder attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# PyCharm
+.idea

--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -1084,7 +1084,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             m = SMB2Message(SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_WRITE_ATTRIBUTES,
-                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
                                               oplock = SMB2_OPLOCK_LEVEL_NONE,
                                               impersonation = SEC_IMPERSONATE,
                                               create_options = 0,

--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -179,6 +179,7 @@ class SMB(NMBSession):
         self._storeFile = self._storeFile_SMB1
         self._storeFileFromOffset = self._storeFileFromOffset_SMB1
         self._deleteFiles = self._deleteFiles_SMB1
+        self._resetFileAttributes = self._resetFileAttributes_SMB1
         self._createDirectory = self._createDirectory_SMB1
         self._deleteDirectory = self._deleteDirectory_SMB1
         self._rename = self._rename_SMB1
@@ -200,6 +201,7 @@ class SMB(NMBSession):
         self._storeFile = self._storeFile_SMB2
         self._storeFileFromOffset = self._storeFileFromOffset_SMB2
         self._deleteFiles = self._deleteFiles_SMB2
+        self._resetFileAttributes = self._resetFileAttributes_SMB2
         self._createDirectory = self._createDirectory_SMB2
         self._deleteDirectory = self._deleteDirectory_SMB2
         self._rename = self._rename_SMB2
@@ -1011,6 +1013,11 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 0x0d,  # SMB2_FILE_DISPOSITION_INFO
                                                data = '\x01'))
+            '''
+                Resources:
+                https://msdn.microsoft.com/en-us/library/cc246560.aspx
+                https://msdn.microsoft.com/en-us/library/cc232098.aspx
+            '''
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, deleteCB, errback, fid = fid)
@@ -1044,6 +1051,103 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                     sendCreate(connect_message.tid)
                 else:
                     errback(OperationFailure('Failed to delete %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
+
+            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
+            messages_history.append(m)
+        else:
+            sendCreate(self.connected_trees[service_name])
+
+    def _resetFileAttributes_SMB2(self, service_name, path_file_pattern, callback, errback, timeout = 30):
+        if not self.has_authenticated:
+            raise NotReadyError('SMB connection not authenticated')
+
+        expiry_time = time.time() + timeout
+        path = path_file_pattern.replace('/', '\\')
+        if path.startswith('\\'):
+            path = path[1:]
+        if path.endswith('\\'):
+            path = path[:-1]
+        messages_history = [ ]
+
+        def sendCreate(tid):
+            create_context_data = binascii.unhexlify("""
+28 00 00 00 10 00 04 00 00 00 18 00 10 00 00 00
+44 48 6e 51 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 18 00 00 00 10 00 04 00
+00 00 18 00 00 00 00 00 4d 78 41 63 00 00 00 00
+00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
+51 46 69 64 00 00 00 00
+""".replace(' ', '').replace('\n', ''))
+
+            m = SMB2Message(SMB2CreateRequest(path,
+                                              file_attributes = 0,
+                                              access_mask = FILE_WRITE_ATTRIBUTES,
+                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                              oplock = SMB2_OPLOCK_LEVEL_NONE,
+                                              impersonation = SEC_IMPERSONATE,
+                                              create_options = 0,
+                                              create_disp = FILE_OPEN,
+                                              create_context_data = create_context_data))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, createCB, errback, tid = tid)
+            messages_history.append(m)
+
+        def createCB(open_message, **kwargs):
+            messages_history.append(open_message)
+            if open_message.status == 0:
+                sendReset(open_message.tid, open_message.payload.fid)
+            else:
+                errback(OperationFailure('Failed to reset attributes of %s on %s: Unable to open file' % ( path, service_name ), messages_history))
+
+        def sendReset(tid, fid):
+            m = SMB2Message(SMB2SetInfoRequest(fid,
+                                               additional_info = 0,
+                                               info_type = SMB2_INFO_FILE,
+                                               file_info_class = 4,  # FileBasicInformation
+                                               data = struct.pack('qqqqii',0,0,0,0,0x80,0))) # FILE_ATTRIBUTE_NORMAL
+            '''
+                Resources:
+                https://msdn.microsoft.com/en-us/library/cc246560.aspx
+                https://msdn.microsoft.com/en-us/library/cc232064.aspx
+                https://msdn.microsoft.com/en-us/library/cc232094.aspx
+                https://msdn.microsoft.com/en-us/library/cc232110.aspx
+            '''
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, resetCB, errback, fid = fid)
+            messages_history.append(m)
+
+        def resetCB(reset_message, **kwargs):
+            messages_history.append(reset_message)
+            if reset_message.status == 0:
+                closeFid(reset_message.tid, kwargs['fid'], status = 0)
+            else:
+                closeFid(reset_message.tid, kwargs['fid'], status = reset_message.status)
+
+        def closeFid(tid, fid, status = None):
+            m = SMB2Message(SMB2CloseRequest(fid))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, status = status)
+            messages_history.append(m)
+
+        def closeCB(close_message, **kwargs):
+            if kwargs['status'] == 0:
+                callback(path_file_pattern)
+            else:
+                errback(OperationFailure('Failed to reset attributes of %s on %s: Reset failed' % ( path, service_name ), messages_history))
+
+        if not self.connected_trees.has_key(service_name):
+            def connectCB(connect_message, **kwargs):
+                messages_history.append(connect_message)
+                if connect_message.status == 0:
+                    self.connected_trees[service_name] = connect_message.tid
+                    sendCreate(connect_message.tid)
+                else:
+                    errback(OperationFailure('Failed to reset attributes of %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
             m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
@@ -2244,6 +2348,9 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             messages_history.append(m)
         else:
             sendDelete(self.connected_trees[service_name])
+
+    def _resetFileAttributes_SMB1(self, service_name, path_file_pattern, callback, errback, timeout = 30):
+        raise NotReadyError('resetFileAttributes is not yet implemented for SMB1')
 
     def _createDirectory_SMB1(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:

--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -377,6 +377,37 @@ class SMBConnection(SMB):
         finally:
             self.is_busy = False
 
+    def resetFileAttributes(self, service_name, path_file_pattern, timeout = 30):
+        """
+        Reset file attributes of one or more regular files or folders.
+        It supports the use of wildcards in file names, allowing for unlocking of multiple files/folders in a single request.
+        This function is very helpful when deleting files/folders that are read-only.
+        Note: this function is currently only implemented for SMB2! Technically, it sets the FILE_ATTRIBUTE_NORMAL flag, therefore clearing all other flags. (See https://msdn.microsoft.com/en-us/library/cc232110.aspx for further information)
+        :param string/unicode service_name: Contains the name of the shared folder.
+        :param string/unicode path_file_pattern: The pathname of the file(s) to be deleted, relative to the service_name.
+                                                 Wildcards may be used in th filename component of the path.
+                                                 If your path/filename contains non-English characters, you must pass in an unicode string.
+        :return: None
+        """
+        if not self.sock:
+            raise NotConnectedError('Not connected to server')
+
+        def cb(r):
+            self.is_busy = False
+
+        def eb(failure):
+            self.is_busy = False
+            raise failure
+
+        self.is_busy = True
+        try:
+            self._resetFileAttributes(service_name, path_file_pattern, cb, eb, timeout = timeout)
+            while self.is_busy:
+                self._pollForNetBIOSPacket(timeout)
+        finally:
+            self.is_busy = False
+
+
     def createDirectory(self, service_name, path, timeout = 30):
         """
         Creates a new directory *path* on the *service_name*.

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -173,6 +173,7 @@ class SMB(NMBSession):
         self._storeFile = self._storeFile_SMB1
         self._storeFileFromOffset = self._storeFileFromOffset_SMB1
         self._deleteFiles = self._deleteFiles_SMB1
+        self._resetFileAttributes = self._resetFileAttributes_SMB1
         self._createDirectory = self._createDirectory_SMB1
         self._deleteDirectory = self._deleteDirectory_SMB1
         self._rename = self._rename_SMB1
@@ -194,6 +195,7 @@ class SMB(NMBSession):
         self._storeFile = self._storeFile_SMB2
         self._storeFileFromOffset = self._storeFileFromOffset_SMB2
         self._deleteFiles = self._deleteFiles_SMB2
+        self._resetFileAttributes = self._resetFileAttributes_SMB2
         self._createDirectory = self._createDirectory_SMB2
         self._deleteDirectory = self._deleteDirectory_SMB2
         self._rename = self._rename_SMB2
@@ -1045,6 +1047,105 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             messages_history.append(m)
         else:
             sendCreate(self.connected_trees[service_name])
+
+    def _resetFileAttributes_SMB2(self, service_name, path_file_pattern, callback, errback, timeout = 30):
+        if not self.has_authenticated:
+            raise NotReadyError('SMB connection not authenticated')
+
+        expiry_time = time.time() + timeout
+        path = path_file_pattern.replace('/', '\\')
+        if path.startswith('\\'):
+            path = path[1:]
+        if path.endswith('\\'):
+            path = path[:-1]
+        messages_history = [ ]
+
+        def sendCreate(tid):
+            create_context_data = binascii.unhexlify("""
+28 00 00 00 10 00 04 00 00 00 18 00 10 00 00 00
+44 48 6e 51 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 18 00 00 00 10 00 04 00
+00 00 18 00 00 00 00 00 4d 78 41 63 00 00 00 00
+00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
+51 46 69 64 00 00 00 00
+""".replace(' ', '').replace('\n', ''))
+
+            m = SMB2Message(SMB2CreateRequest(path,
+                                              file_attributes = 0,
+                                              access_mask = FILE_WRITE_ATTRIBUTES,
+                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                              oplock = SMB2_OPLOCK_LEVEL_NONE,
+                                              impersonation = SEC_IMPERSONATE,
+                                              create_options = 0,
+                                              create_disp = FILE_OPEN,
+                                              create_context_data = create_context_data))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, createCB, errback, tid = tid)
+            messages_history.append(m)
+
+        def createCB(open_message, **kwargs):
+            messages_history.append(open_message)
+            if open_message.status == 0:
+                sendReset(open_message.tid, open_message.payload.fid)
+            else:
+                errback(OperationFailure('Failed to reset attributes of %s on %s: Unable to open file' % ( path, service_name ), messages_history))
+
+        def sendReset(tid, fid):
+            m = SMB2Message(SMB2SetInfoRequest(fid,
+                                               additional_info = 0,
+                                               info_type = SMB2_INFO_FILE,
+                                               file_info_class = 4,  # FileBasicInformation
+                                               data = struct.pack('qqqqii',0,0,0,0,0x80,0))) # FILE_ATTRIBUTE_NORMAL
+            '''
+                Resources:
+                https://msdn.microsoft.com/en-us/library/cc246560.aspx
+                https://msdn.microsoft.com/en-us/library/cc232064.aspx
+                https://msdn.microsoft.com/en-us/library/cc232094.aspx
+                https://msdn.microsoft.com/en-us/library/cc232110.aspx
+            '''
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, resetCB, errback, fid = fid)
+            messages_history.append(m)
+
+        def resetCB(reset_message, **kwargs):
+            messages_history.append(reset_message)
+            if reset_message.status == 0:
+                closeFid(reset_message.tid, kwargs['fid'], status = 0)
+            else:
+                closeFid(reset_message.tid, kwargs['fid'], status = reset_message.status)
+
+        def closeFid(tid, fid, status = None):
+            m = SMB2Message(SMB2CloseRequest(fid))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, status = status)
+            messages_history.append(m)
+
+        def closeCB(close_message, **kwargs):
+            if kwargs['status'] == 0:
+                callback(path_file_pattern)
+            else:
+                errback(OperationFailure('Failed to reset attributes of %s on %s: Reset failed' % ( path, service_name ), messages_history))
+
+        if service_name not in self.connected_trees:
+            def connectCB(connect_message, **kwargs):
+                messages_history.append(connect_message)
+                if connect_message.status == 0:
+                    self.connected_trees[service_name] = connect_message.tid
+                    sendCreate(connect_message.tid)
+                else:
+                    errback(OperationFailure('Failed to reset attributes of %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
+
+            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
+            messages_history.append(m)
+        else:
+            sendCreate(self.connected_trees[service_name])
+
+
 
     def _createDirectory_SMB2(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:
@@ -2238,6 +2339,9 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             messages_history.append(m)
         else:
             sendDelete(self.connected_trees[service_name])
+
+    def _resetFileAttributes_SMB1(self, service_name, path_file_pattern, callback, errback, timeout = 30):
+        raise NotReadyError('resetFileAttributes is not yet implemented for SMB1')
 
     def _createDirectory_SMB1(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -1007,6 +1007,11 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 0x0d,  # SMB2_FILE_DISPOSITION_INFO
                                                data = b'\x01'))
+            '''
+                Resources:
+                https://msdn.microsoft.com/en-us/library/cc246560.aspx
+                https://msdn.microsoft.com/en-us/library/cc232098.aspx
+            '''
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, deleteCB, errback, fid = fid)

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -1073,7 +1073,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             m = SMB2Message(SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_WRITE_ATTRIBUTES,
-                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
                                               oplock = SMB2_OPLOCK_LEVEL_NONE,
                                               impersonation = SEC_IMPERSONATE,
                                               create_options = 0,


### PR DESCRIPTION
This is useful for deletion of files/folders that are readOnly with write permissions, which fails without reseting the file/folder attributes.
this function is only implemented for SMB2.
it has been tested with python2 and python3 with Windows Server 2008.