### PR TITLE
Bugfix: support_dfs is not always in kwargs.

### DIFF
--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -1981,7 +1981,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 elif end_of_search:
                     callback(results)
                 else:
-                    sendFindNext(find_message.tid, sid, last_name_offset, kwargs['support_dfs'])
+                    sendFindNext(find_message.tid, sid, last_name_offset, kwargs.get('support_dfs', False))
             else:
                 errback(OperationFailure('Failed to list %s on %s: Unable to retrieve file list' % ( path, service_name ), messages_history))
 
@@ -2043,7 +2043,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 elif end_of_search:
                     callback(results)
                 else:
-                    sendFindNext(find_message.tid, kwargs['sid'], last_name_offset, kwargs['support_dfs'])
+                    sendFindNext(find_message.tid, kwargs['sid'], last_name_offset, kwargs.get('support_dfs', False))
             else:
                 errback(OperationFailure('Failed to list %s on %s: Unable to retrieve file list' % ( path, service_name ), messages_history))
 

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -1977,7 +1977,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 elif end_of_search:
                     callback(results)
                 else:
-                    sendFindNext(find_message.tid, sid, last_name_offset, kwargs['support_dfs'])
+                    sendFindNext(find_message.tid, sid, last_name_offset, kwargs.get('support_dfs', False))
             else:
                 errback(OperationFailure('Failed to list %s on %s: Unable to retrieve file list' % ( path, service_name ), messages_history))
 
@@ -2039,7 +2039,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 elif end_of_search:
                     callback(results)
                 else:
-                    sendFindNext(find_message.tid, kwargs['sid'], last_name_offset, kwargs['support_dfs'])
+                    sendFindNext(find_message.tid, kwargs['sid'], last_name_offset, kwargs.get('support_dfs', False))
             else:
                 errback(OperationFailure('Failed to list %s on %s: Unable to retrieve file list' % ( path, service_name ), messages_history))
 


### PR DESCRIPTION
Hi,
With pysmb 1.1.16, I sometimes get an exception during connection: 
[...]
File "/usr/local/lib/python3.4/dist-packages/smb/base.py", line 1874, in findFirstCB
      sendFindNext(find_message.tid, sid, last_name_offset, kwargs['support_dfs'])
      KeyError: 'support_dfs'

It seems that the 'support_dfs' parameter is not always provided. I made a simple patch for both Python2 and Python3 to get its default value if not present.

Maybe this is a bit naïve and the reason why 'support_dfs' is not always provided should be investigated further. Anyway, this is an easy fix that worked well for me.

Regards.