### PR TITLE
hmac.new() wants explicit digestmod argument

### DIFF
--- a/python3/smb/ntlm.py
+++ b/python3/smb/ntlm.py
@@ -161,12 +161,12 @@ def generateChallengeResponseV2(password, user, server_challenge, server_info, d
     d = MD4()
     d.update(password.encode('UTF-16LE'))
     ntlm_hash = d.digest()   # The NT password hash
-    response_key = hmac.new(ntlm_hash, (user.upper() + domain).encode('UTF-16LE')).digest()  # The NTLMv2 password hash. In [MS-NLMP], this is the result of NTOWFv2 and LMOWFv2 functions
+    response_key = hmac.new(ntlm_hash, (user.upper() + domain).encode('UTF-16LE'), 'md5').digest()  # The NTLMv2 password hash. In [MS-NLMP], this is the result of NTOWFv2 and LMOWFv2 functions
     temp = client_timestamp + client_challenge + domain.encode('UTF-16LE') + server_info
 
-    nt_challenge_response = hmac.new(response_key, server_challenge + temp).digest()
-    lm_challenge_response = hmac.new(response_key, server_challenge + client_challenge).digest() + client_challenge
-    session_key = hmac.new(response_key, nt_challenge_response).digest()
+    nt_challenge_response = hmac.new(response_key, server_challenge + temp, 'md5').digest()
+    lm_challenge_response = hmac.new(response_key, server_challenge + client_challenge, 'md5').digest() + client_challenge
+    session_key = hmac.new(response_key, nt_challenge_response, 'md5').digest()
 
     return nt_challenge_response, lm_challenge_response, session_key
 


### PR DESCRIPTION
hmac.new defaults to md5 for the digest if it isn't specified. Soon Python apparently will require the digest to be explicitly specified.

Fixes the following error with python3.4:

PendingDeprecationWarning: HMAC() without an explicit digestmod argument is deprecated.