### PR TITLE
Fix listing of shares for long listings

### DIFF
--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -500,9 +500,9 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 data_bytes = read_message.payload.data
 
                 if data_bytes[3] & 0x02 == 0:
-                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len])
                 else:
-                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len])
             else:
                 closeFid(read_message.tid, kwargs['fid'])
                 errback(OperationFailure('Failed to list shares: Unable to retrieve shared device list', messages_history))


### PR DESCRIPTION
Not sure if this is exactly the right solution but I've implemented @donwayo 's suggestion to fixing the unpack error in `listShares` when the list of shares was too long. Works but we still don't know where 24 tail bytes being stripped were for.

Fixes: #75 

Signed-off-by: Philippe Pepos Petitclerc <ppeposp@gmail.com>