### PR TITLE
Discuss: SMB 2.1 support

### DIFF
--- a/python2/smb/SMBConnection.py
+++ b/python2/smb/SMBConnection.py
@@ -585,8 +585,14 @@ class SMBConnection(SMB):
 
         type_, flags, length = struct.unpack('>BBH', data)
         if type_ == 0x0:
+            # This is a Direct TCP packet
+            # The length is specified in the header from byte 8. (0-indexed) 
+            # we read a structure assuming NBT, so to get the real length
+            # combine the length and flag fields together
             length = length + (flags << 16)
         else:
+            # This is a NetBIOS over TCP (NBT) packet
+            # The length is specified in the header from byte 16. (0-indexed)
             if flags & 0x01:
                 length = length | 0x10000
 

--- a/python2/smb/SMBConnection.py
+++ b/python2/smb/SMBConnection.py
@@ -584,8 +584,11 @@ class SMBConnection(SMB):
                     raise ex
 
         type_, flags, length = struct.unpack('>BBH', data)
-        if flags & 0x01:
-            length = length | 0x10000
+        if type_ == 0x0:
+            length = length + (flags << 16)
+        else:
+            if flags & 0x01:
+                length = length | 0x10000
 
         read_len = length
         while read_len > 0:

--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -97,6 +97,13 @@ class SMB(NMBSession):
         self.max_write_size = 0     #: Similar to MaxWriteSize as described in [MS-SMB2] 2.2.4
         self.max_transact_size = 0  #: Similar to MaxTransactSize as described in [MS-SMB2] 2.2.4
         self.session_id = 0         #: Similar to SessionID as described in [MS-SMB2] 2.2.4. This will be set in _updateState_SMB2 method
+        self.smb2_dialect = 0
+
+
+        # SMB 2.1 attributes
+        self.cap_leasing = False
+        self.cap_multi_credit = False
+        self.credits = 0   # how many credits we're allowed to spend per request
 
         self._setupSMB1Methods()
 
@@ -131,6 +138,22 @@ class SMB(NMBSession):
             next_message_offset = 0
             if self.is_using_smb2:
                 next_message_offset = self.smb_message.next_command_offset
+
+                # update how many credits we're allowed to spend on requests
+                self.credits = self.smb_message.credit_response
+
+                # SMB2 CANCEL commands do not consume message IDs
+                if self.smb_message.command is not SMB2_COM_CANCEL:
+                    print "PACKET FROM SERVER, " + str(self.smb_message.command) + " CREDIT CHARGE RECV: " + str(self.smb_message.credit_charge)
+                    if self.smb_message.credit_charge > 0:
+                        # Let's update the sequenceWindow based on the CreditsCharged
+                        # In the SMB 2.0.2 dialect, this field MUST NOT be used and MUST be reserved.
+                        # The sender MUST set this to 0, and the receiver MUST ignore it.
+                        # In all other dialects, this field indicates the number of credits that this request consumes.
+                        print "UPDATING MID TO ADD CREDIT CHARGE FROM SERVER"
+                        print "BEFORE: " + str(self.mid)
+                        self.mid = self.mid + (self.smb_message.credit_charge - 1)
+                        print "AFTER: " + str(self.mid)
 
             if i > 0:
                 if not self.is_using_smb2:
@@ -244,10 +267,23 @@ class SMB(NMBSession):
         if message.isReply:
             if message.command == SMB2_COM_NEGOTIATE:
                 if message.status == 0:
-                    self.has_negotiated = True
-                    self.log.info('SMB2 dialect negotiation successful')
-                    self._updateServerInfo(message.payload)
-                    self._handleNegotiateResponse(message)
+
+                    if self.smb_message.payload.dialect_revision == SMB2_DIALECT_2ALL:
+                        # Dialects from SMB 2.1 must be negotiated in a second negotiate phase
+                        # We send a SMB2 Negotiate Request to accomplish this
+                        self._sendSMBMessage(SMB2Message(self, SMB2NegotiateRequest()))
+                    else:
+                        if self.smb_message.payload.dialect_revision == SMB2_DIALECT_21:
+                            # We negotiated SMB 2.1.
+                            # we must now send credit requests (MUST!)
+                            #self.send_credits_request = True
+                            pass
+
+                        self.has_negotiated = True
+                        self.log.info('SMB2 dialect negotiation successful')
+                        self.dialect = self.smb_message.payload.dialect_revision
+                        self._updateServerInfo(message.payload)
+                        self._handleNegotiateResponse(message)
                 else:
                     raise ProtocolError('Unknown status value (0x%08X) in SMB2_COM_NEGOTIATE' % message.status,
                                         message.raw_data, message)
@@ -294,11 +330,17 @@ class SMB(NMBSession):
         self.max_write_size = payload.max_write_size
         self.use_plaintext_authentication = False   # SMB2 never allows plaintext authentication
 
+        if (self.capabilities & SMB2_GLOBAL_CAP_LEASING) == SMB2_GLOBAL_CAP_LEASING:
+            self.cap_leasing = True
+
+        if (self.capabilities & SMB2_GLOBAL_CAP_LARGE_MTU) == SMB2_GLOBAL_CAP_LARGE_MTU:
+            self.cap_multi_credit = True
+
 
     def _handleNegotiateResponse_SMB2(self, message):
         ntlm_data = ntlm.generateNegotiateMessage()
         blob = securityblob.generateNegotiateSecurityBlob(ntlm_data)
-        self._sendSMBMessage(SMB2Message(SMB2SessionSetupRequest(blob)))
+        self._sendSMBMessage(SMB2Message(self, SMB2SessionSetupRequest(blob)))
 
 
     def _handleSessionChallenge_SMB2(self, message, ntlm_token):
@@ -330,7 +372,7 @@ class SMB(NMBSession):
             self.log.debug('LM challenge response is "%s" (%d bytes)', binascii.hexlify(lm_challenge_response), len(lm_challenge_response))
 
         blob = securityblob.generateAuthSecurityBlob(ntlm_data)
-        self._sendSMBMessage(SMB2Message(SMB2SessionSetupRequest(blob)))
+        self._sendSMBMessage(SMB2Message(self, SMB2SessionSetupRequest(blob)))
 
         if self.security_mode & SMB2_NEGOTIATE_SIGNING_REQUIRED:
             self.log.info('Server requires all SMB messages to be signed')
@@ -361,7 +403,7 @@ class SMB(NMBSession):
         messages_history = [ ]
 
         def connectSrvSvc(tid):
-            m = SMB2Message(SMB2CreateRequest('srvsvc',
+            m = SMB2Message(self, SMB2CreateRequest('srvsvc',
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_READ_EA | FILE_WRITE_EA | READ_CONTROL | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -393,7 +435,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 2c 1c b7 6c 12 98 40 45 03 00 00 00 00 00 00 00
 01 00 00 00
 """.replace(' ', '').replace('\n', ''))
-                m = SMB2Message(SMB2WriteRequest(create_message.payload.fid, data_bytes, 0))
+                m = SMB2Message(self, SMB2WriteRequest(create_message.payload.fid, data_bytes, 0))
                 m.tid = create_message.tid
                 self._sendSMBMessage(m)
                 self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, rpcBindCB, errback, fid = create_message.payload.fid)
@@ -404,7 +446,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def rpcBindCB(trans_message, **kwargs):
             messages_history.append(trans_message)
             if trans_message.status == 0:
-                m = SMB2Message(SMB2ReadRequest(kwargs['fid'], read_len = 1024, read_offset = 0))
+                m = SMB2Message(self, SMB2ReadRequest(kwargs['fid'], read_len = 1024, read_offset = 0))
                 m.tid = trans_message.tid
                 self._sendSMBMessage(m)
                 self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, rpcReadCB, errback, fid = kwargs['fid'])
@@ -437,7 +479,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 01 00 00 00 01 00 00 00 04 00 02 00 00 00 00 00
 00 00 00 00 ff ff ff ff 08 00 02 00 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-                m = SMB2Message(SMB2IoctlRequest(kwargs['fid'], 0x0011C017, flags = 0x01, max_out_size = 8196, in_data = data_bytes))
+                m = SMB2Message(self, SMB2IoctlRequest(kwargs['fid'], 0x0011C017, flags = 0x01, max_out_size = 8196, in_data = data_bytes))
                 m.tid = read_message.tid
                 self._sendSMBMessage(m)
                 self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, listShareResultsCB, errback, fid = kwargs['fid'])
@@ -493,7 +535,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
         def sendReadRequest(tid, fid, data_bytes):
             read_count = min(4280, self.max_read_size)
-            m = SMB2Message(SMB2ReadRequest(fid, 0, read_count))
+            m = SMB2Message(self, SMB2ReadRequest(fid, 0, read_count))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, readCB, errback,
@@ -514,7 +556,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to list shares: Unable to retrieve shared device list', messages_history))
 
         def closeFid(tid, fid, results = None, error = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, results = results, error = error)
@@ -535,7 +577,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to list shares: Unable to connect to IPC$', messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), path )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), path )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = path)
             messages_history.append(m)
@@ -564,7 +606,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -586,10 +628,15 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to list %s on %s: Unable to open directory' % ( path, service_name ), messages_history))
 
         def sendQuery(tid, fid, data_buf):
-            m = SMB2Message(SMB2QueryDirectoryRequest(fid, pattern,
+            if self.smb2_dialect != SMB2_DIALECT_2 and self.cap_multi_credit:
+                output_buf_len = 64 * 1024 * (self.credits - 1)
+            else:
+                output_buf_len = self.max_transact_size
+
+            m = SMB2Message(self, SMB2QueryDirectoryRequest(fid, pattern,
                                                       info_class = 0x03,   # FileBothDirectoryInformation
                                                       flags = 0,
-                                                      output_buf_len = self.max_transact_size))
+                                                      output_buf_len = output_buf_len))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, queryCB, errback, fid = fid, data_buf = data_buf)
@@ -638,7 +685,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             return ''
 
         def closeFid(tid, fid, results = None, error = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, results = results, error = error)
@@ -659,7 +706,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to list %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -687,7 +734,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -714,7 +761,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to get attributes for %s on %s: Unable to open remote file object' % ( path, service_name ), messages_history))
 
         def closeFid(tid, fid, info = None, error = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, info = info, error = error)
@@ -735,7 +782,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to get attributes for %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -756,7 +803,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         results = [ ]
 
         def sendCreate(tid):
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -772,7 +819,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def createCB(create_message, **kwargs):
             messages_history.append(create_message)
             if create_message.status == 0:
-                m = SMB2Message(SMB2QueryInfoRequest(create_message.payload.fid,
+                m = SMB2Message(self, SMB2QueryInfoRequest(create_message.payload.fid,
                                                      flags = 0,
                                                      additional_info = OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
                                                      info_type = SMB2_INFO_SECURITY,
@@ -795,7 +842,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(query_message.tid, kwargs['fid'], error = query_message.status)
 
         def closeFid(tid, fid, result = None, error = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, result = result, error = error)
@@ -816,7 +863,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to get the security descriptor of %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -848,7 +895,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -865,7 +912,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def createCB(create_message, **kwargs):
             messages_history.append(create_message)
             if create_message.status == 0:
-                m = SMB2Message(SMB2QueryInfoRequest(create_message.payload.fid,
+                m = SMB2Message(self, SMB2QueryInfoRequest(create_message.payload.fid,
                                                      flags = 0,
                                                      additional_info = 0,
                                                      info_type = SMB2_INFO_FILE,
@@ -899,7 +946,12 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
         def sendRead(tid, fid, offset, remaining_len, read_len, file_attributes):
             read_count = min(self.max_read_size, remaining_len)
-            m = SMB2Message(SMB2ReadRequest(fid, offset, read_count))
+
+            if self.smb2_dialect != SMB2_DIALECT_2 and self.cap_multi_credit:
+                max_read_count = 64 * 1024 * (self.credits -1)
+                read_count = min(read_count, max_read_count)
+
+            m = SMB2Message(self, SMB2ReadRequest(fid, offset, read_count))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, readCB, errback,
@@ -925,7 +977,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(read_message.tid, kwargs['fid'], error = read_message.status)
 
         def closeFid(tid, fid, ret = None, error = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, ret = ret, error = error)
@@ -946,7 +998,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to retrieve %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -979,7 +1031,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = ATTR_ARCHIVE,
                                               access_mask = FILE_READ_DATA | FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | FILE_READ_EA | FILE_WRITE_EA | READ_CONTROL | SYNCHRONIZE,
                                               share_access = 0,
@@ -1006,11 +1058,14 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to store %s on %s: Unable to open file' % ( path, service_name ), messages_history))
 
         def sendWrite(tid, fid, offset):
-            write_count = self.max_write_size
+            if self.smb2_dialect != SMB2_DIALECT_2 and self.cap_multi_credit:
+                write_count = 64 * 1024 * (self.credits -1)
+            else:
+                write_count = self.max_write_size
             data = file_obj.read(write_count)
             data_len = len(data)
             if data_len > 0:
-                m = SMB2Message(SMB2WriteRequest(fid, data, offset))
+                m = SMB2Message(self, SMB2WriteRequest(fid, data, offset))
                 m.tid = tid
                 self._sendSMBMessage(m)
                 self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, writeCB, errback, fid = fid, offset = offset+data_len)
@@ -1027,7 +1082,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to store %s on %s: Write failed' % ( path, service_name ), messages_history))
 
         def closeFid(tid, fid, error = None, offset = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, fid = fid, offset = offset, error = error)
@@ -1048,7 +1103,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to store %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1077,7 +1132,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = DELETE | FILE_READ_ATTRIBUTES,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -1104,7 +1159,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to delete %s on %s: Unable to open file' % ( path, service_name ), messages_history))
 
         def sendDelete(tid, fid):
-            m = SMB2Message(SMB2SetInfoRequest(fid,
+            m = SMB2Message(self, SMB2SetInfoRequest(fid,
                                                additional_info = 0,
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 0x0d,  # SMB2_FILE_DISPOSITION_INFO
@@ -1127,7 +1182,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(delete_message.tid, kwargs['fid'], status = delete_message.status)
 
         def closeFid(tid, fid, status = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, status = status)
@@ -1148,7 +1203,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to delete %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1177,7 +1232,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
 
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_WRITE_ATTRIBUTES,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -1199,7 +1254,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to reset attributes of %s on %s: Unable to open file' % ( path, service_name ), messages_history))
 
         def sendReset(tid, fid):
-            m = SMB2Message(SMB2SetInfoRequest(fid,
+            m = SMB2Message(self, SMB2SetInfoRequest(fid,
                                                additional_info = 0,
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 4,  # FileBasicInformation
@@ -1224,7 +1279,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(reset_message.tid, kwargs['fid'], status = reset_message.status)
 
         def closeFid(tid, fid, status = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, status = status)
@@ -1245,7 +1300,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to reset attributes of %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1273,7 +1328,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_WRITE_DATA | FILE_READ_EA | FILE_WRITE_EA | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | READ_CONTROL | DELETE | SYNCHRONIZE,
                                               share_access = 0,
@@ -1295,7 +1350,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to create directory %s on %s: Create failed' % ( path, service_name ), messages_history))
 
         def closeFid(tid, fid):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback)
@@ -1313,7 +1368,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to create directory %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1341,7 +1396,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = DELETE | FILE_READ_ATTRIBUTES,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -1363,7 +1418,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to delete %s on %s: Unable to open directory' % ( path, service_name ), messages_history))
 
         def sendDelete(tid, fid):
-            m = SMB2Message(SMB2SetInfoRequest(fid,
+            m = SMB2Message(self, SMB2SetInfoRequest(fid,
                                                additional_info = 0,
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 0x0d,  # SMB2_FILE_DISPOSITION_INFO
@@ -1381,7 +1436,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(delete_message.tid, kwargs['fid'], status = delete_message.status)
 
         def closeFid(tid, fid, status = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, status = status)
@@ -1402,7 +1457,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to delete %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1437,7 +1492,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
 51 46 69 64 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(old_path,
+            m = SMB2Message(self, SMB2CreateRequest(old_path,
                                               file_attributes = 0,
                                               access_mask = DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -1460,7 +1515,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
         def sendRename(tid, fid):
             data = '\x00'*16 + struct.pack('<I', len(new_path)*2) + new_path.encode('UTF-16LE')
-            m = SMB2Message(SMB2SetInfoRequest(fid,
+            m = SMB2Message(self, SMB2SetInfoRequest(fid,
                                                additional_info = 0,
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 0x0a,  # SMB2_FILE_RENAME_INFO
@@ -1478,7 +1533,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(rename_message.tid, kwargs['fid'], status = rename_message.status)
 
         def closeFid(tid, fid, status = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, status = status)
@@ -1499,7 +1554,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to rename %s on %s: Unable to connect to shared device' % ( old_path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1525,7 +1580,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 00 00 00 00 00 00 00 00 00 00 00 00 10 00 04 00
 00 00 18 00 00 00 00 00 4d 78 41 63 00 00 00 00
 """.replace(' ', '').replace('\n', ''))
-            m = SMB2Message(SMB2CreateRequest(path,
+            m = SMB2Message(self, SMB2CreateRequest(path,
                                               file_attributes = 0,
                                               access_mask = FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
                                               share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -1547,7 +1602,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 errback(OperationFailure('Failed to list snapshots %s on %s: Unable to open file/directory' % ( old_path, service_name ), messages_history))
 
         def sendEnumSnapshots(tid, fid):
-            m = SMB2Message(SMB2IoctlRequest(fid,
+            m = SMB2Message(self, SMB2IoctlRequest(fid,
                                              ctlcode = 0x00144064,  # FSCTL_SRV_ENUMERATE_SNAPSHOTS
                                              flags = 0x0001,
                                              in_data = ''))
@@ -1569,7 +1624,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 closeFid(kwargs['tid'], kwargs['fid'], status = enum_message.status)
 
         def closeFid(tid, fid, status = None, results = None):
-            m = SMB2Message(SMB2CloseRequest(fid))
+            m = SMB2Message(self, SMB2CloseRequest(fid))
             m.tid = tid
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, closeCB, errback, status = status, results = results)
@@ -1590,7 +1645,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                 else:
                     errback(OperationFailure('Failed to list snapshots %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
 
-            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            m = SMB2Message(self, SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
             self._sendSMBMessage(m)
             self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
             messages_history.append(m)
@@ -1607,7 +1662,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             else:
                 errback(OperationFailure('Echo failed', messages_history))
 
-        m = SMB2Message(SMB2EchoRequest())
+        m = SMB2Message(self, SMB2EchoRequest())
         self._sendSMBMessage(m)
         self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, echoCB, errback)
         messages_history.append(m)

--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -101,9 +101,8 @@ class SMB(NMBSession):
 
 
         # SMB 2.1 attributes
-        self.cap_leasing = False
-        self.cap_multi_credit = False
-        self.credits = 0   # how many credits we're allowed to spend per request
+        self.cap_multi_credit = False  #: Does the connection support multi-credit operations?
+        self.credits = 0               #: how many credits we're allowed to spend per request
 
         self._setupSMB1Methods()
 
@@ -320,9 +319,6 @@ class SMB(NMBSession):
         self.max_read_size = payload.max_read_size
         self.max_write_size = payload.max_write_size
         self.use_plaintext_authentication = False   # SMB2 never allows plaintext authentication
-
-        if (self.capabilities & SMB2_GLOBAL_CAP_LEASING) == SMB2_GLOBAL_CAP_LEASING:
-            self.cap_leasing = True
 
         if (self.capabilities & SMB2_GLOBAL_CAP_LARGE_MTU) == SMB2_GLOBAL_CAP_LARGE_MTU:
             self.cap_multi_credit = True

--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -144,16 +144,12 @@ class SMB(NMBSession):
 
                 # SMB2 CANCEL commands do not consume message IDs
                 if self.smb_message.command is not SMB2_COM_CANCEL:
-                    print "PACKET FROM SERVER, " + str(self.smb_message.command) + " CREDIT CHARGE RECV: " + str(self.smb_message.credit_charge)
                     if self.smb_message.credit_charge > 0:
-                        # Let's update the sequenceWindow based on the CreditsCharged
+                        # Update the message ID based on the credit charge
                         # In the SMB 2.0.2 dialect, this field MUST NOT be used and MUST be reserved.
                         # The sender MUST set this to 0, and the receiver MUST ignore it.
                         # In all other dialects, this field indicates the number of credits that this request consumes.
-                        print "UPDATING MID TO ADD CREDIT CHARGE FROM SERVER"
-                        print "BEFORE: " + str(self.mid)
                         self.mid = self.mid + (self.smb_message.credit_charge - 1)
-                        print "AFTER: " + str(self.mid)
 
             if i > 0:
                 if not self.is_using_smb2:
@@ -273,12 +269,7 @@ class SMB(NMBSession):
                         # We send a SMB2 Negotiate Request to accomplish this
                         self._sendSMBMessage(SMB2Message(self, SMB2NegotiateRequest()))
                     else:
-                        if self.smb_message.payload.dialect_revision == SMB2_DIALECT_21:
-                            # We negotiated SMB 2.1.
-                            # we must now send credit requests (MUST!)
-                            #self.send_credits_request = True
-                            pass
-
+                        self.smb2_dialect = self.smb_message.payload.dialect_revision
                         self.has_negotiated = True
                         self.log.info('SMB2 dialect negotiation successful')
                         self.dialect = self.smb_message.payload.dialect_revision

--- a/python2/smb/smb2_constants.py
+++ b/python2/smb/smb2_constants.py
@@ -50,9 +50,12 @@ SMB2_COMMAND_NAMES = {
 }
 
 # Values for dialect_revision field in SMB2NegotiateResponse class
-SMB2_DIALECT_2 = 0x0202
-SMB2_DIALECT_21 = 0x0210
-SMB2_DIALECT_2ALL = 0x02FF
+SMB2_DIALECT_2 = 0x0202  # 2.0.2 - First SMB2 version
+SMB2_DIALECT_21 = 0x0210  # 2.1 - Windows 7
+SMB2_DIALET_30 = 0x0300  # 3.0 - Windows 8
+SMB2_DIALECT_302 = 0x0302  # 3.0.2 - Windows 8.1
+SMB2_DIALECT_311 = 0x0311  # 3.1.1 - Windows 10
+SMB2_DIALECT_2ALL = 0x02FF  # Wildcard (for negotiation only)
 
 # Bit mask for SecurityMode field in SMB2NegotiateResponse class
 SMB2_NEGOTIATE_SIGNING_ENABLED = 0x0001
@@ -65,6 +68,17 @@ SMB2_SHARE_TYPE_PRINTER = 0x03
 
 # Bitmask for Capabilities in SMB2TreeConnectResponse class
 SMB2_SHARE_CAP_DFS = 0x0008
+
+
+# SMB 2.1 / 3 Capabilities flags
+SMB2_GLOBAL_CAP_DFS = 0x01
+SMB2_GLOBAL_CAP_LEASING = 0x02
+SMB2_GLOBAL_CAP_LARGE_MTU = 0x04
+SMB2_GLOBAL_CAP_MULTI_CHANNEL = 0x08
+SMB2_GLOBAL_CAP_PERSISTENT_HANDLES = 0x10
+SMB2_GLOBAL_CAP_DIRECTORY_LEASING = 0x20
+SMB2_GLOBAL_CAP_ENCRYPTION = 0x40
+
 
 # Values for OpLockLevel field in SMB2CreateRequest class
 SMB2_OPLOCK_LEVEL_NONE = 0x00

--- a/python2/smb/smb2_structs.py
+++ b/python2/smb/smb2_structs.py
@@ -143,7 +143,6 @@ class SMB2Message:
         return headers_data + self.data
 
     def decode(self, buf):
-        print "SMB2 message decode"
         """
         Decodes the SMB message in buf.
         All fields of the SMB2Message object will be reset to default values before decoding.
@@ -644,7 +643,6 @@ class SMB2ReadRequest(Structure):
         # to ( 1 + (Length - 1) / 65536 )
         if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
             message.credit_charge = int(1 + (self.read_len -1) / 65536)
-            print "setting credit charge to " + str(message.credit_charge)
 
 
 class SMB2ReadResponse(Structure):

--- a/python2/smb/smb2_structs.py
+++ b/python2/smb/smb2_structs.py
@@ -1,5 +1,5 @@
 
-import os, sys, struct, types, logging, binascii, time
+import os, sys, struct, types, logging, binascii, time, uuid
 from StringIO import StringIO
 from smb_structs import ProtocolError
 from smb_constants import *
@@ -23,8 +23,15 @@ class SMB2Message:
     log = logging.getLogger('SMB.SMB2Message')
     protocol = 2
 
-    def __init__(self, payload = None):
+
+    def __init__(self, conn = None, payload = None):
+        """
+        Initialise a new SMB2 Message.
+        conn - reference to the connection, the SMB class
+        payload - the message payload, if any
+        """
         self.reset()
+        self.conn = conn
         if payload:
             self.payload = payload
             self.payload.initMessage(self)
@@ -60,6 +67,10 @@ class SMB2Message:
         self.pid = 0
         self.tid = 0
 
+        # credit related
+        self.credit_charge = 0
+        self.credit_request = 1
+
         # Not used in this class. Maintained for compatibility with SMBMessage class
         self.flags2 = 0
         self.uid = 0
@@ -69,21 +80,70 @@ class SMB2Message:
     def encode(self):
         """
         Encode this SMB2 message into a series of bytes suitable to be embedded with a NetBIOS session message.
+        AssertionError will be raised if this SMB message has not been initialized with an SMB instance
         AssertionError will be raised if this SMB message has not been initialized with a Payload instance
+
+        The header format is:
+        - Protocol ID
+        - Structure Size
+        - Credit Charge
+        - Status / Channel Sequence
+        - Command
+        - Credit Request / Credit Response
+        - Flags
+        - Next Compound
+        - MessageId
+        - Reserved
+        - TreeId
+        - Session ID
+        - Signature
 
         @return: a string containing the encoded SMB2 message
         """
         assert self.payload
+        assert self.conn
 
         self.pid = os.getpid()
         self.payload.prepare(self)
 
+        # If Connection.Dialect is not "2.0.2" and if Connection.SupportsMultiCredit is TRUE, the
+        # CreditCharge field in the SMB2 header MUST be set to ( 1 + (OutputBufferLength - 1) / 65536 )
+        # This only applies to SMB2ReadRequest, SMB2WriteRequest, SMB2IoctlRequest and SMB2QueryDirectory
+        # See: MS-SMB2 3.2.4.1.5: For all other requests, the client MUST set CreditCharge to 1, even if the 
+        # payload size of a request or the anticipated response is greater than 65536.
+        if self.conn.smb2_dialect != SMB2_DIALECT_2:
+            if self.conn.cap_multi_credit:
+                # self.credit_charge will be set by some commands if necessary (Read/Write/Ioctl/QueryDirectory)
+                # If not set, but dialect is SMB 2.1 or above, we must set it to 1
+                if self.credit_charge is 0:
+                    self.credit_charge = 1
+            else:
+                # If >= SMB 2.1, but server does not support multi credit operations we must set to 1
+                self.credit_charge = 1
+
+        if self.mid > 3:
+            self.credit_request = 127
+
         headers_data = struct.pack(self.HEADER_STRUCT_FORMAT,
-                                   '\xFESMB', self.HEADER_SIZE, 0, self.status, self.command, 0, self.flags) + \
-                       struct.pack(self.SYNC_HEADER_STRUCT_FORMAT, self.next_command_offset, self.mid, self.pid, self.tid, self.session_id, self.signature)
+                                   '\xFESMB',  # Protocol ID
+                                   self.HEADER_SIZE,  # Structure Size
+                                   self.credit_charge,  # Credit Charge
+                                   self.status,  # Status / Channel Sequence
+                                   self.command,  # Command
+                                   self.credit_request,  # Credit Request / Credit Response
+                                   self.flags, # Flags
+                                   ) + \
+                       struct.pack(self.SYNC_HEADER_STRUCT_FORMAT,
+                                    self.next_command_offset, # Next Compound
+                                    self.mid,  # Message ID
+                                    self.pid,  # Process ID
+                                    self.tid,  # Tree ID
+                                    self.session_id,  # Session ID
+                                    self.signature)  # Signature
         return headers_data + self.data
 
     def decode(self, buf):
+        print "SMB2 message decode"
         """
         Decodes the SMB message in buf.
         All fields of the SMB2Message object will be reset to default values before decoding.
@@ -106,7 +166,8 @@ class SMB2Message:
         self.reset()
 
         protocol, struct_size, self.credit_charge, self.status, \
-            self.command, self.credit_re, self.flags = struct.unpack(self.HEADER_STRUCT_FORMAT, buf[:self.HEADER_STRUCT_SIZE])
+            self.command, self.credit_response, \
+            self.flags = struct.unpack(self.HEADER_STRUCT_FORMAT, buf[:self.HEADER_STRUCT_SIZE])
 
         if protocol != '\xFESMB':
             raise ProtocolError('Invalid 4-byte SMB2 protocol field', buf)
@@ -187,6 +248,53 @@ class Structure:
 
     def decode(self, message):
         raise NotImplementedError
+
+
+class SMB2NegotiateRequest(Structure):
+    """
+    2.2.3 SMB2 NEGOTIATE Request
+    The SMB2 NEGOTIATE Request packet is used by the client to notify the server what dialects of the SMB 2 Protocol
+    the client understands. This request is composed of an SMB2 header, as specified in section 2.2.1,
+    followed by this request structure:
+
+    SMB2 Negotiate Request Packet structure:
+        StructureSize (2 bytes)
+        DialectCount (2 bytes)
+        SecurityMode (2 bytes)
+        Reserved (2 bytes)
+        Capabilities (4 bytes)
+        ClientGuid (16 bytes)
+        ClientStartTime (8 bytes):
+        ClientStartTime (8 bytes):
+        Dialects (variable): An array of one or more 16-bit integers
+
+    References:
+    ===========
+    - [MS-SMB2]: 2.2.3
+
+    """
+
+
+    STRUCTURE_FORMAT = "<HHHHI16sQHH"
+    STRUCTURE_SIZE = struct.calcsize(STRUCTURE_FORMAT)
+
+    def initMessage(self, message):
+        Structure.initMessage(self, message)
+        message.command = SMB2_COM_NEGOTIATE
+
+    def prepare(self, message):
+        # TODO! Do we need to save the GUID and present it later in other requests?
+        # The SMB docs don't exactly explain what the guid is for
+        message.data = struct.pack(self.STRUCTURE_FORMAT,
+                                   36,           # Structure size. Must be 36 as mandated by [MS-SMB2] 2.2.3
+                                   2,            # DialectCount
+                                   0x01,         # Security mode
+                                   0,            # Reserved
+                                   0x00,         # Capabilities
+                                   uuid.uuid4().bytes, # Client GUID
+                                   0,            # Client start time
+                                   SMB2_DIALECT_2,
+                                   SMB2_DIALECT_21)
 
 
 class SMB2NegotiateResponse(Structure):
@@ -465,6 +573,13 @@ class SMB2WriteRequest(Structure):
                                    0,  # WriteChannelInfoLength
                                    self.flags) + self.data
 
+        # MS-SMB2 3.2.4.7
+        # If a client requests writing to a file, Connection.Dialect is not "2.0.2", and if
+        # Connection.SupportsMultiCredit is TRUE, the CreditCharge field in the SMB2 header MUST be set
+        # to ( 1 + (Length - 1) / 65536 )
+        if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
+            message.credit_charge = int(1 + (len(self.data) -1) / 65536)
+
 
 class SMB2WriteResponse(Structure):
     """
@@ -523,6 +638,14 @@ class SMB2ReadRequest(Structure):
                                    0     # ReadChannelInfoLength
                                   ) + '\0'
 
+        # MS-SMB2 3.2.4.6
+        # If a client requests reading from a file, Connection.Dialect is not "2.0.2", and if
+        # Connection.SupportsMultiCredit is TRUE, the CreditCharge field in the SMB2 header MUST be set
+        # to ( 1 + (Length - 1) / 65536 )
+        if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
+            message.credit_charge = int(1 + (self.read_len -1) / 65536)
+            print "setting credit charge to " + str(message.credit_charge)
+
 
 class SMB2ReadResponse(Structure):
     """
@@ -578,6 +701,11 @@ class SMB2IoctlRequest(Structure):
                                    self.flags,   # Flags
                                    0    # Reserved
                                   ) + self.in_data
+
+        # If Connection.SupportsMultiCredit is TRUE, the CreditCharge field in the SMB2 header
+        # SHOULD be set to (max(InputCount, MaxOutputResponse) - 1) / 65536 + 1
+        if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
+            message.credit_charge = (max(len(self.in_data), self.max_out_size) - 1) / 65536 + 1
 
 
 class SMB2IoctlResponse(Structure):
@@ -686,6 +814,12 @@ class SMB2QueryDirectoryRequest(Structure):
                                    SMB2Message.HEADER_SIZE + self.STRUCTURE_SIZE,  # FileNameOffset
                                    len(self.filename)*2,
                                    self.output_buf_len) + self.filename.encode('UTF-16LE')
+
+        # MS-SMB2 3.2.4.17
+        # If Connection.Dialect is not "2.0.2" and if Connection.SupportsMultiCredit is TRUE, the
+        # CreditCharge field in the SMB2 header MUST be set to ( 1 + (OutputBufferLength - 1) / 65536 )
+        if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
+            message.credit_charge = int(1 + (self.output_buf_len -1) / 65536)
 
 
 class SMB2QueryDirectoryResponse(Structure):

--- a/python2/smb/smb2_structs.py
+++ b/python2/smb/smb2_structs.py
@@ -881,6 +881,12 @@ class SMB2QueryInfoRequest(Structure):
                                    self.fid                # FileId
                                   ) + self.input_buf
 
+        # MS-SMB2 3.2.4.17
+        # If Connection.Dialect is not "2.0.2" and if Connection.SupportsMultiCredit is TRUE, the
+        # CreditCharge field in the SMB2 header MUST be set to ( 1 + (OutputBufferLength - 1) / 65536 )
+        if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
+            message.credit_charge = int(1 + ((self.output_buf_len + len(self.input_buf)) -1) / 65536)
+
 
 class SMB2QueryInfoResponse(Structure):
     """
@@ -938,6 +944,12 @@ class SMB2SetInfoRequest(Structure):
                                    self.additional_info,  # AdditionalInformation
                                    self.fid               # FileId
                                   ) + self.data
+
+        # MS-SMB2 3.2.4.17
+        # If Connection.Dialect is not "2.0.2" and if Connection.SupportsMultiCredit is TRUE, the
+        # CreditCharge field in the SMB2 header MUST be set to ( 1 + (OutputBufferLength - 1) / 65536 )
+        if message.conn.smb2_dialect != SMB2_DIALECT_2 and message.conn.cap_multi_credit:
+            message.credit_charge = int(1 + (len(self.data) -1) / 65536)
 
 class SMB2SetInfoResponse(Structure):
     """

--- a/python2/smb/smb_structs.py
+++ b/python2/smb/smb_structs.py
@@ -17,7 +17,7 @@ for i, ( name, dialect ) in enumerate([ ( 'NT_LAN_MANAGER_DIALECT', 'NT LM 0.12'
     globals()[name] = i
 
 DIALECTS2 = [ ]
-for i, ( name, dialect ) in enumerate([ ( 'SMB2_DIALECT', 'SMB 2.002' ) ]):
+for i, ( name, dialect ) in enumerate([ ( 'SMB2_DIALECT', 'SMB 2.002' ), ('SMB2_WILDCARD', 'SMB 2.???') ]):
     DIALECTS2.append(dialect)
     globals()[name] = i + len(DIALECTS)
 


### PR DESCRIPTION
This is actually a fairly complete implementation of SMB 2.1 for pysmb (python 2 only for now, will add python 3 code once we're happy with the python 2 code). 

This PR is intended for discussion at first, rather than a merge. Perhaps you could give me access to make commits to a branch on miketeo/pysmb and then we can both make changes on that, and then when happy later merge in 2.1 support.

A few important notes:

- I altered the NBT packet handling in SMBConnection.py. Without these changes connections simply timed out with SMB 2.1. I made these changes because other SMB clients do this. For example impacket (which is also Python, and has full SMB2/3 support) does it: https://github.com/CoreSecurity/impacket/blob/3ea914bde68f473bf94f43d2345f08d383bd71fc/impacket/nmb.py#L935

- I added two SMB 2.1+ capability flags to the 'SMB' class - cap_leasing and cap_multi_credit. I didn't yet implement anything to do with cap_leasing (I haven't read what it even is yet). I also added a smb2_dialect attribute to store the particular version of SMB 2.1 in use - its important to know this for calculating credit_charge etc. I also added a 'credits' attribute which stores the credits the server granted us in the last response packet.

The capability attributes are set in _updateServerInfo_SMB2()
The smb2_dialect is updated in _updateState_SMB2 upon SMB2_COM_NEGOTIATE response

- I modified _updateState_SMB2 so that when an SMB2_COM_NEGOTIATE response is recieved and the dialect is set to the wildcard dialect (SMB2_DIALECT_2ALL) then it sends a new SMB2_COM_NEGOTIATE which I added to smb2_structs. 

- The biggest change in base.py is the addition of a new argument to the SMB2Message() constructor so that smb2 messages are given a copy of the SMB object. This is required because there is code within each individual SMB2 message which needs to check the server dialect, the connection capabilities and the credit balance. Its also just nice to have a reference to the SMB object from within the object so methods there can find out the connection state. You might not like this, I am not sure, let me know!

- another change to base.py relates to the maximum size of read requests, write requests, and query directory requests. Before SMB 2.1 SMB servers always returned 65536 as the maximum number of bytes. From SMB 2.1 the SMB server allows a huge maximum transact size, but to use it you must use credits. Each credit you're granted lets you use 65536 bytes / 64kb. So if the server grants the client 16 credits then the actual max transaction size is 16 * 64kb (Although the client must never let the credit balance reach zero, so actually the maximum is 15 * 64kb so 1 credit is left). 

So to facilitate this in sendRead, sendWrite and sendQuery there are if statements to check if we're using SMB 2.1 or later and if the server has set multi_credit, and if it has, it sets the maximum size based on the number of credits the server previously granted. 

This has a significant increase in performance - pysmb using SMB 2.1 now uses less requests to request large files or write to large files. Before the maximum size of each request was 64kb, now it can be much larger. In tests against Samba I found I could use up to 2MB (32 credits) because the server was granting me 33 credits on each response.

- I modified smb2_constants.py to add all the SMB2/3 versions and I also added all of the "SMB3" capabilities (they're called SMB3 capabilities, but they're used in SMB 2.1. good job microsoft).

- I changed smb2_structs.py to add the new SMB2_NEGOTIATE_REQUEST which is used to negotiate all protocol versions past SMB 2.02. I also added attributes onto the SMB2Message for credit_charge and credit_request which both must be sent if SMB 2.1 or later is in use. credit_charge defaults to 1 if SMB 2.1 is in use, but if sending a read/write/query request then a credit_charge is calculated based upon the size of the transaction (see above). 

- The final change is to smb_structs.py to add the SMB2 wildcard type during initial protocol negotiation. 
