### PR TITLE
Fix ambiguous failure when echoing unicode strings

### DIFF
--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -2652,6 +2652,9 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
     def _echo_SMB1(self, data, callback, errback, timeout = 30):
         messages_history = [ ]
 
+        if not isinstance(data, type(b'')):
+            raise TypeError('Echo data must be %s not %s' % (type(b'').__name__, type(data).__name__))
+
         def echoCB(echo_message, **kwargs):
             messages_history.append(echo_message)
             if not echo_message.status.hasError:

--- a/python2/smb/smb_structs.py
+++ b/python2/smb/smb_structs.py
@@ -1280,7 +1280,7 @@ class ComEchoRequest(Payload):
     - [MS-CIFS]: 2.2.4.39.1
     """
 
-    def __init__(self, echo_data = '', echo_count = 1):
+    def __init__(self, echo_data = b'', echo_count = 1):
         self.echo_count = echo_count
         self.echo_data = echo_data
 

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -2648,6 +2648,9 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
     def _echo_SMB1(self, data, callback, errback, timeout = 30):
         messages_history = [ ]
 
+        if not isinstance(data, type(b'')):
+            raise TypeError('Echo data must be %s not %s' % (type(b'').__name__, type(data).__name__))
+
         def echoCB(echo_message, **kwargs):
             messages_history.append(echo_message)
             if not echo_message.status.hasError:

--- a/python3/smb/smb_structs.py
+++ b/python3/smb/smb_structs.py
@@ -1279,7 +1279,7 @@ class ComEchoRequest(Payload):
     - [MS-CIFS]: 2.2.4.39.1
     """
 
-    def __init__(self, echo_data = '', echo_count = 1):
+    def __init__(self, echo_data = b'', echo_count = 1):
         self.echo_count = echo_count
         self.echo_data = echo_data
 


### PR DESCRIPTION
In Python 3 (and Python 2 with `from __future__ import unicode_literals`), doing an SMB1 `echo(data)` fails with a `str` + `bytes` concatenation exception if `data` is a string.

This error doesn't make it obvious that the `echo()` call needs the `data` parameter to be a string of **bytes**, and makes it look like SMB1 is broken. I've just spent a while chasing this error, and ended up adding the checks that you can see in this patch to make the reason more clear.

_PS:_ Even without the checks, the `echo_data` parameter in the `ComEchoRequest` class had a bad default. If ommited, it would error out.