### PR TITLE
Fix failure with long share listings (more thorough)

### DIFF
--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -502,13 +502,12 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def readCB(read_message, **kwargs):
             messages_history.append(read_message)
             if read_message.status == 0:
-                data_len = read_message.payload.data_length
                 data_bytes = read_message.payload.data
 
                 if ord(data_bytes[3]) & 0x02 == 0:
-                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
                 else:
-                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
             else:
                 closeFid(read_message.tid, kwargs['fid'])
                 errback(OperationFailure('Failed to list shares: Unable to retrieve shared device list', messages_history))
@@ -1946,13 +1945,12 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def readCB(read_message, **kwargs):
             messages_history.append(read_message)
             if not read_message.status.hasError:
-                data_len = read_message.payload.data_length
                 data_bytes = read_message.payload.data
 
                 if ord(data_bytes[3]) & 0x02 == 0:
-                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
                 else:
-                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
             else:
                 closeFid(read_message.tid, kwargs['fid'])
                 errback(OperationFailure('Failed to list shares: Unable to retrieve shared device list', messages_history))

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -496,13 +496,12 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def readCB(read_message, **kwargs):
             messages_history.append(read_message)
             if read_message.status == 0:
-                data_len = read_message.payload.data_length
                 data_bytes = read_message.payload.data
 
                 if data_bytes[3] & 0x02 == 0:
-                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
                 else:
-                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
             else:
                 closeFid(read_message.tid, kwargs['fid'])
                 errback(OperationFailure('Failed to list shares: Unable to retrieve shared device list', messages_history))
@@ -1942,13 +1941,12 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
         def readCB(read_message, **kwargs):
             messages_history.append(read_message)
             if not read_message.status.hasError:
-                data_len = read_message.payload.data_length
                 data_bytes = read_message.payload.data
 
                 if data_bytes[3] & 0x02 == 0:
-                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    sendReadRequest(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
                 else:
-                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
+                    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:])
             else:
                 closeFid(read_message.tid, kwargs['fid'])
                 errback(OperationFailure('Failed to list shares: Unable to retrieve shared device list', messages_history))


### PR DESCRIPTION
I'm seeing the problem reported in issue #75, whereas a `.listShares()` fails with the following error:

```
Traceback (most recent call last):
  File "./pysmb-test.py", line 74, in <module>
    main()
  File "./pysmb-test.py", line 66, in main
    for entry in conn.listShares():
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/smb/SMBConnection.py", line 149, in listShares
    self._pollForNetBIOSPacket(timeout)
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/smb/SMBConnection.py", line 614, in _pollForNetBIOSPacket
    self.feedData(data)
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/nmb/base.py", line 54, in feedData
    self._processNMBSessionPacket(self.data_nmb)
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/nmb/base.py", line 75, in _processNMBSessionPacket
    self.onNMBSessionMessage(packet.flags, packet.data)
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/smb/base.py", line 138, in onNMBSessionMessage
    if self._updateState(self.smb_message):
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/smb/base.py", line 279, in _updateState_SMB2
    req.callback(message, **req.kwargs)
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/smb/base.py", line 506, in readCB
    decodeResults(read_message.tid, kwargs['fid'], kwargs['data_bytes'] + data_bytes[24:data_len-24])
  File "/home/vagrant/bpstat-venv/lib64/python3.6/site-packages/smb/base.py", line 476, in decodeResults
    max_length, _, length = struct.unpack('<III', data_bytes[offset:offset+12])
struct.error: unpack requires a buffer of 12 bytes
```

As mentioned in that issue, it looks like 24 bytes are being removed from a data buffer, causing the error. I must admit that I don't understand the reason for the magic 24 bytes, so I'm taking a wild guess here that the trim at the end of the buffer is supposed to be an erroneous compensation for the 24 trimmed at the start.

This patch does about the same as PR #101, but is more thorough, touching all instances that look the same. It seems to do the trick for me (until now, at least).

Anyway, If my guess is wrong, ignore it. 😄 