### PR TITLE
Bugfix: Unhandled exception due to short NBNS queries

### DIFF
--- a/python3/nmb/base.py
+++ b/python3/nmb/base.py
@@ -156,21 +156,25 @@ class NBNS:
         opcode = (code >> 11) & 0x0F
         flags = (code >> 4) & 0x7F
         rcode = code & 0x0F
-        numnames = data[self.HEADER_STRUCT_SIZE + 44]
 
-        if numnames > 0:
-            ret = [ ]
-            offset = self.HEADER_STRUCT_SIZE + 45
+        try:
+            numnames = data[self.HEADER_STRUCT_SIZE + 44]
 
-            for i in range(0, numnames):
-                mynme = data[offset:offset + 15]
-                mynme = mynme.strip()
-                ret.append(( str(mynme, 'ascii'), data[offset+15] ))
-                offset += 18
+            if numnames > 0:
+                ret = [ ]
+                offset = self.HEADER_STRUCT_SIZE + 45
 
-            return trn_id, ret
-        else:
-            return trn_id, None
+                for i in range(0, numnames):
+                    mynme = data[offset:offset + 15]
+                    mynme = mynme.strip()is
+                    ret.append(( str(mynme, 'ascii'), data[offset+15] ))
+                    offset += 18
+
+                return trn_id, ret
+        except IndexError:
+            pass
+
+        return trn_id, None
 
     #
     # Contributed by Jason Anderson


### PR DESCRIPTION
This commit fixes the following bug:
A NetBIOS object processes all UDP packets addressed to listen_port. This raises an IndexError on short-enough packets.
(Example scenario where this exception is regularly thrown: listen_port is 137 and the pysmb machine happens to be a WINS server, which causes the latter to regularly receive packets on port 137.)