### PR TITLE
Allow `resetFileAttributes` to set specific attributes.

### DIFF
--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -429,17 +429,21 @@ class SMBConnection(SMB):
         finally:
             self.is_busy = False
 
-    def resetFileAttributes(self, service_name, path_file_pattern, timeout = 30):
+    def resetFileAttributes(self, service_name, path_file_pattern, file_attributes = ATTR_NORMAL, timeout = 30):
         """
         Reset file attributes of one or more regular files or folders.
         It supports the use of wildcards in file names, allowing for unlocking of multiple files/folders in a single request.
         This function is very helpful when deleting files/folders that are read-only.
-        Note: this function is currently only implemented for SMB2! Technically, it sets the FILE_ATTRIBUTE_NORMAL flag, therefore clearing all other flags. (See https://msdn.microsoft.com/en-us/library/cc232110.aspx for further information)
+        By default, it sets the ATTR_NORMAL flag, therefore clearing all other flags.
+        (See https://msdn.microsoft.com/en-us/library/cc232110.aspx for further information)
+
+        Note: this function is currently only implemented for SMB2!
 
         :param string/unicode service_name: Contains the name of the shared folder.
         :param string/unicode path_file_pattern: The pathname of the file(s) to be deleted, relative to the service_name.
                                                  Wildcards may be used in the filename component of the path.
                                                  If your path/filename contains non-English characters, you must pass in an unicode string.
+        :param int file_attributes: The desired file attributes to set. Defaults to `ATTR_NORMAL`.
         :return: None
         """
         if not self.sock:
@@ -454,12 +458,11 @@ class SMBConnection(SMB):
 
         self.is_busy = True
         try:
-            self._resetFileAttributes(service_name, path_file_pattern, cb, eb, timeout = timeout)
+            self._resetFileAttributes(service_name, path_file_pattern, cb, eb, file_attributes, timeout)
             while self.is_busy:
                 self._pollForNetBIOSPacket(timeout)
         finally:
             self.is_busy = False
-
 
     def createDirectory(self, service_name, path, timeout = 30):
         """

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -1288,7 +1288,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
         sendCreate(tid)
 
-    def _resetFileAttributes_SMB2(self, service_name, path_file_pattern, callback, errback, timeout = 30):
+    def _resetFileAttributes_SMB2(self, service_name, path_file_pattern, callback, errback, file_attributes = ATTR_NORMAL, timeout = 30):
         if not self.has_authenticated:
             raise NotReadyError('SMB connection not authenticated')
 
@@ -1336,7 +1336,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                                                additional_info = 0,
                                                info_type = SMB2_INFO_FILE,
                                                file_info_class = 4,  # FileBasicInformation
-                                               data = struct.pack('qqqqii',0,0,0,0,0x80,0))) # FILE_ATTRIBUTE_NORMAL
+                                               data = struct.pack('qqqqii', 0, 0, 0, 0, file_attributes, 0)))
             # [MS-SMB2]: 2.2.39, [MS-FSCC]: 2.4, [MS-FSCC]: 2.4.7, [MS-FSCC]: 2.6
             m.tid = tid
             self._sendSMBMessage(m)
@@ -1378,8 +1378,6 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             messages_history.append(m)
         else:
             sendCreate(self.connected_trees[service_name])
-
-
 
     def _createDirectory_SMB2(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:
@@ -2696,7 +2694,7 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
         sendDelete(tid)
 
-    def _resetFileAttributes_SMB1(self, service_name, path_file_pattern, callback, errback, timeout = 30):
+    def _resetFileAttributes_SMB1(self, service_name, path_file_pattern, callback, errback, file_attributes=ATTR_NORMAL, timeout = 30):
         raise NotReadyError('resetFileAttributes is not yet implemented for SMB1')
 
     def _createDirectory_SMB1(self, service_name, path, callback, errback, timeout = 30):


### PR DESCRIPTION
This change allows the `resetFileAttribute` method to optionally specify the `file_attributes`. 
If no attribute is specified, then the behavior is identical to before (attributes are set to ATTR_ARCHIVE). 

I was considering making a new method for this, but it seemed less bloated to just extend the existing method.
Comments welcome! 