### PR TITLE
pass timeout to socket in SMBConnection.py

### DIFF
--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -115,7 +115,7 @@ class SMBConnection(SMB):
             self.sock.settimeout(timeout)
             self.sock.connect(( ip, port ))
         else:
-            self.sock = socket.create_connection(( ip, port ))
+            self.sock = socket.create_connection(( ip, port ), timeout = timeout)
 
         self.is_busy = True
         try:


### PR DESCRIPTION
the timeout parameter was not passed to socket.create_conneciton() which is critical to me