### PR TITLE
Copy SMB messages for exception OperationFailure 

### DIFF
--- a/python3/smb/smb_structs.py
+++ b/python3/smb/smb_structs.py
@@ -1,5 +1,6 @@
 
 import os, sys, struct, types, logging, binascii, time
+from copy import copy
 from io import StringIO
 from .smb_constants import *
 from .strategy import DataFaultToleranceStrategy
@@ -60,7 +61,8 @@ class OperationFailure(Exception):
 
     def __init__(self, message, smb_messages):
         self.message = message
-        self.smb_messages = smb_messages
+        self.smb_messages = [copy(msg) for msg in smb_messages]
+        self.args = (message, self.smb_messages)
 
     def __str__(self):
         b = StringIO()

--- a/python3/tests/SMBConnectionTests/test_messages_in_exception.py
+++ b/python3/tests/SMBConnectionTests/test_messages_in_exception.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from io import BytesIO
+from typing import Optional
+
+from nose2.tools.decorators import with_setup, with_teardown
+from smb.SMBConnection import SMBConnection
+from smb import smb_structs
+from .util import getConnectionInfo
+
+
+conn: Optional[SMBConnection] = None
+TEST_FILE_NAME = 'StoreTest.txt'
+TEST_SERVICE_NAME = 'smbtest'
+
+
+def setup_func_SMB2():
+    global conn
+    smb_structs.SUPPORT_SMB2 = True
+
+    info = getConnectionInfo()
+    conn = SMBConnection(info['user'], info['password'], info['client_name'], info['server_name'], use_ntlm_v2 = True, is_direct_tcp=True)
+    assert conn.connect(info['server_ip'], info['server_port'])
+
+
+def teardown_func():
+    global conn
+    conn.close()
+
+
+@with_setup(setup_func_SMB2)
+@with_teardown(teardown_func)
+def test_messages_in_exception_SMB2():
+    info = getConnectionInfo()
+
+    with open(f'''\\\\{info['server_ip']}\\{TEST_SERVICE_NAME}\\{TEST_FILE_NAME}''', 'w'):
+        try:
+            conn.storeFile(TEST_SERVICE_NAME, TEST_FILE_NAME, BytesIO(b'Test data'))
+        except Exception as ex:
+            conn.retrieveFile(TEST_SERVICE_NAME, TEST_FILE_NAME, BytesIO())
+            last_smb_message = ex.args[1][-1]
+            if last_smb_message.status != 0xC0000043:
+                raise ex


### PR DESCRIPTION
There is a small problem when handling OperationFailure exceptions - the field 'smb_messages' contains the latest messages, not the ones that were there when the exception occurred.