### PR TITLE
tests: Replace SafeConfigParser with ConfigParser.

### DIFF
--- a/python2/tests/DirectSMBConnectionTests/util.py
+++ b/python2/tests/DirectSMBConnectionTests/util.py
@@ -1,10 +1,10 @@
 
 import os
-from ConfigParser import SafeConfigParser
+from ConfigParser import ConfigParser
 
 def getConnectionInfo():
     config_filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'connection.ini')
-    cp = SafeConfigParser()
+    cp = ConfigParser()
     cp.read(config_filename)
 
     info = {

--- a/python2/tests/DirectSMBTwistedTests/util.py
+++ b/python2/tests/DirectSMBTwistedTests/util.py
@@ -1,10 +1,10 @@
 
 import os
-from ConfigParser import SafeConfigParser
+from ConfigParser import ConfigParser
 
 def getConnectionInfo():
     config_filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'connection.ini')
-    cp = SafeConfigParser()
+    cp = ConfigParser()
     cp.read(config_filename)
 
     info = {

--- a/python2/tests/SMBConnectionTests/util.py
+++ b/python2/tests/SMBConnectionTests/util.py
@@ -1,10 +1,10 @@
 
 import os
-from ConfigParser import SafeConfigParser
+from ConfigParser import ConfigParser
 
 def getConnectionInfo():
     config_filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'connection.ini')
-    cp = SafeConfigParser()
+    cp = ConfigParser()
     cp.read(config_filename)
 
     info = {

--- a/python2/tests/SMBTwistedTests/util.py
+++ b/python2/tests/SMBTwistedTests/util.py
@@ -1,10 +1,10 @@
 
 import os
-from ConfigParser import SafeConfigParser
+from ConfigParser import ConfigParser
 
 def getConnectionInfo():
     config_filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'connection.ini')
-    cp = SafeConfigParser()
+    cp = ConfigParser()
     cp.read(config_filename)
 
     info = {

--- a/python3/tests/DirectSMBConnectionTests/util.py
+++ b/python3/tests/DirectSMBConnectionTests/util.py
@@ -1,10 +1,10 @@
 
 import os
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 def getConnectionInfo():
     config_filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'connection.ini')
-    cp = SafeConfigParser()
+    cp = ConfigParser()
     cp.read(config_filename)
 
     info = {

--- a/python3/tests/SMBConnectionTests/util.py
+++ b/python3/tests/SMBConnectionTests/util.py
@@ -1,10 +1,10 @@
 
 import os
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 def getConnectionInfo():
     config_filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'connection.ini')
-    cp = SafeConfigParser()
+    cp = ConfigParser()
     cp.read(config_filename)
 
     info = {


### PR DESCRIPTION
configparser.SafeConfigParser has been deprecated since python 3.2 and has been dropped entirely from python 3.12. Replace with ConfigParser.

This allows building pysmb and running the tests against Python 3.12.