### PR TITLE
Add function `setLastWriteTime` for assinging field `last_write_time` of a file/folder

### DIFF
--- a/python2/smb/SMBConnection.py
+++ b/python2/smb/SMBConnection.py
@@ -350,7 +350,7 @@ class SMBConnection(SMB):
             self.is_busy = False
 
         return results[0]
-
+    
     def storeFile(self, service_name, path, file_obj, timeout = 30):
         """
         Store the contents of the *file_obj* at *path* on the *service_name*.
@@ -463,7 +463,35 @@ class SMBConnection(SMB):
                 self._pollForNetBIOSPacket(timeout)
         finally:
             self.is_busy = False
-
+    
+    def setLastWriteTime(self, service_name, path, last_write_time, timeout = 30):
+        """
+        Set last modification time of a regular file or folder.
+        
+        Note: this function is currently only implemented for SMB2!
+        
+        :param string/unicode service_name: Contains the name of the shared folder.
+        :param string/unicode path: Path of the file on the remote server. If the file cannot be opened for writing, an :doc:`OperationFailure<smb_exceptions>` will be raised.
+        :param float last_write_time: float value in number of seconds since 1970-01-01 00:00:00.
+        """
+        if not self.sock:
+            raise NotConnectedError('Not connected to server')
+        
+        def cb(r):
+            self.is_busy = False
+        
+        def eb(failure):
+            self.is_busy = False
+            raise failure
+        
+        self.is_busy = True
+        try:
+            self._setLastWriteTime(service_name, path, cb, eb, last_write_time, timeout = timeout)
+            while self.is_busy:
+                self._pollForNetBIOSPacket(timeout)
+        finally:
+            self.is_busy = False
+    
     def createDirectory(self, service_name, path, timeout = 30):
         """
         Creates a new directory *path* on the *service_name*.

--- a/python2/smb/base.py
+++ b/python2/smb/base.py
@@ -7,7 +7,7 @@ from smb_structs import *
 from smb2_structs import *
 from .security_descriptors import SecurityDescriptor
 from nmb.base import NMBSession
-from utils import convertFILETIMEtoEpoch
+from utils import convertFILETIMEtoEpoch, convertEpochToFILETIME
 import ntlm, securityblob
 
 try:
@@ -1383,7 +1383,98 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             self._pushToArray(messages_history, m)
         else:
             sendCreate(self.connected_trees[service_name])
-
+    
+    def _setLastWriteTime_SMB2(self, service_name, path, callback, errback, last_write_time, timeout = 30):
+        if not self.has_authenticated:
+            raise NotReadyError('SMB connection not authenticated')
+        
+        expiry_time = time.time() + timeout
+        path = path.replace('/', '\\')
+        if path.startswith('\\'):
+            path = path[1:]
+        if path.endswith('\\'):
+            path = path[:-1]
+        messages_history = [ ]
+        
+        def sendCreate(tid):
+            create_context_data = binascii.unhexlify("""
+28 00 00 00 10 00 04 00 00 00 18 00 10 00 00 00
+44 48 6e 51 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 18 00 00 00 10 00 04 00
+00 00 18 00 00 00 00 00 4d 78 41 63 00 00 00 00
+00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
+51 46 69 64 00 00 00 00
+""".replace(' ', '').replace('\n', ''))
+            
+            m = SMB2Message(SMB2CreateRequest(path,
+                                              file_attributes = 0,
+                                              access_mask = FILE_WRITE_ATTRIBUTES,
+                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                              oplock = SMB2_OPLOCK_LEVEL_NONE,
+                                              impersonation = SEC_IMPERSONATE,
+                                              create_options = 0,
+                                              create_disp = FILE_OPEN,
+                                              create_context_data = create_context_data))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, createCB, errback, tid = tid)
+            self._pushToArray(messages_history, m)
+        
+        def createCB(open_message, **kwargs):
+            self._pushToArray(messages_history, open_message)
+            if open_message.status == 0:
+                sendSet(kwargs['tid'], open_message.payload.fid)
+            else:
+                errback(OperationFailure('Failed to set mtime of %s on %s: Unable to open file' % ( path, service_name ), messages_history))
+        
+        def sendSet(tid, fid):
+            m = SMB2Message(SMB2SetInfoRequest(fid,
+                                               additional_info = 0,
+                                               info_type = SMB2_INFO_FILE,
+                                               file_info_class = 4,  # FileBasicInformation
+                                               data = struct.pack('qqqqii', 0, 0, convertEpochToFILETIME(last_write_time), 0, 0, 0)))
+            # [MS-SMB2]: 2.2.39, [MS-FSCC]: 2.4, [MS-FSCC]: 2.4.7, [MS-FSCC]: 2.6
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, setCB, errback, tid = tid, fid = fid)
+            self._pushToArray(messages_history, m)
+        
+        def setCB(set_message, **kwargs):
+            self._pushToArray(messages_history, set_message)
+            if set_message.status == 0:
+                closeFid(kwargs['tid'], kwargs['fid'], status = 0)
+            else:
+                closeFid(kwargs['tid'], kwargs['fid'], status = set_message.status)
+        
+        def closeFid(tid, fid, status = None):
+            m = SMB2Message(SMB2CloseRequest(fid))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, status = status)
+            self._pushToArray(messages_history, m)
+        
+        def closeCB(close_message, **kwargs):
+            if kwargs['status'] == 0:
+                callback(path)
+            else:
+                errback(OperationFailure('Failed to set mtime of %s on %s: Operation failed' % ( path, service_name ), messages_history))
+        
+        if not self.connected_trees.has_key(service_name):
+            def connectCB(connect_message, **kwargs):
+                self._pushToArray(messages_history, connect_message)
+                if connect_message.status == 0:
+                    self.connected_trees[service_name] = connect_message.tid
+                    sendCreate(connect_message.tid)
+                else:
+                    errback(OperationFailure('Failed to set mtime of %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
+            
+            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
+            self._pushToArray(messages_history, m)
+        else:
+            sendCreate(self.connected_trees[service_name])
+    
     def _createDirectory_SMB2(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:
             raise NotReadyError('SMB connection not authenticated')
@@ -2702,7 +2793,10 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
     def _resetFileAttributes_SMB1(self, service_name, path_file_pattern, callback, errback, file_attributes=ATTR_NORMAL, timeout = 30):
         raise NotReadyError('resetFileAttributes is not yet implemented for SMB1')
-
+    
+    def _setLastWriteTime_SMB1(self, service_name, path, callback, errback, last_write_time, timeout = 30):
+        raise NotReadyError('setLastWriteTime is not yet implemented for SMB1')
+    
     def _createDirectory_SMB1(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:
             raise NotReadyError('SMB connection not authenticated')

--- a/python2/smb/utils/__init__.py
+++ b/python2/smb/utils/__init__.py
@@ -1,3 +1,6 @@
 
 def convertFILETIMEtoEpoch(t):
     return (t - 116444736000000000L) / 10000000.0;
+
+def convertEpochToFILETIME(t):
+    return int(t * 10000000.0) + 116444736000000000L

--- a/python3/smb/SMBConnection.py
+++ b/python3/smb/SMBConnection.py
@@ -475,7 +475,35 @@ class SMBConnection(SMB):
                 self._pollForNetBIOSPacket(timeout)
         finally:
             self.is_busy = False
-
+    
+    def setLastWriteTime(self, service_name, path, last_write_time, timeout = 30):
+        """
+        Set last modification time of a regular file or folder.
+        
+        Note: this function is currently only implemented for SMB2!
+        
+        :param string/unicode service_name: Contains the name of the shared folder.
+        :param string/unicode path: Path of the file on the remote server. If the file cannot be opened for writing, an :doc:`OperationFailure<smb_exceptions>` will be raised.
+        :param float last_write_time: float value in number of seconds since 1970-01-01 00:00:00.
+        """
+        if not self.sock:
+            raise NotConnectedError('Not connected to server')
+        
+        def cb(r):
+            self.is_busy = False
+        
+        def eb(failure):
+            self.is_busy = False
+            raise failure
+        
+        self.is_busy = True
+        try:
+            self._setLastWriteTime(service_name, path, cb, eb, last_write_time, timeout)
+            while self.is_busy:
+                self._pollForNetBIOSPacket(timeout)
+        finally:
+            self.is_busy = False
+    
     def createDirectory(self, service_name, path, timeout = 30):
         """
         Creates a new directory *path* on the *service_name*.

--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -9,7 +9,7 @@ from .smb_structs import *
 from .smb2_structs import *
 from .security_descriptors import SecurityDescriptor
 from nmb.base import NMBSession
-from .utils import convertFILETIMEtoEpoch
+from .utils import convertFILETIMEtoEpoch, convertEpochToFILETIME
 from . import ntlm, securityblob
 from .strategy import DataFaultToleranceStrategy
 
@@ -188,6 +188,7 @@ class SMB(NMBSession):
         self._storeFileFromOffset = self._storeFileFromOffset_SMB1
         self._deleteFiles = self._deleteFiles_SMB1
         self._resetFileAttributes = self._resetFileAttributes_SMB1
+        self._setLastWriteTime = self._setLastWriteTime_SMB1
         self._createDirectory = self._createDirectory_SMB1
         self._deleteDirectory = self._deleteDirectory_SMB1
         self._rename = self._rename_SMB1
@@ -211,6 +212,7 @@ class SMB(NMBSession):
         self._storeFileFromOffset = self._storeFileFromOffset_SMB2
         self._deleteFiles = self._deleteFiles_SMB2
         self._resetFileAttributes = self._resetFileAttributes_SMB2
+        self._setLastWriteTime = self._setLastWriteTime_SMB2
         self._createDirectory = self._createDirectory_SMB2
         self._deleteDirectory = self._deleteDirectory_SMB2
         self._rename = self._rename_SMB2
@@ -1415,7 +1417,98 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             self._pushToArray(messages_history, m)
         else:
             sendCreate(self.connected_trees[service_name])
-
+    
+    def _setLastWriteTime_SMB2(self, service_name, path, callback, errback, last_write_time, timeout = 30):
+        if not self.has_authenticated:
+            raise NotReadyError('SMB connection not authenticated')
+        
+        expiry_time = time.time() + timeout
+        path = path.replace('/', '\\')
+        if path.startswith('\\'):
+            path = path[1:]
+        if path.endswith('\\'):
+            path = path[:-1]
+        messages_history = [ ]
+        
+        def sendCreate(tid):
+            create_context_data = binascii.unhexlify(b"""
+28 00 00 00 10 00 04 00 00 00 18 00 10 00 00 00
+44 48 6e 51 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 18 00 00 00 10 00 04 00
+00 00 18 00 00 00 00 00 4d 78 41 63 00 00 00 00
+00 00 00 00 10 00 04 00 00 00 18 00 00 00 00 00
+51 46 69 64 00 00 00 00
+""".replace(b' ', b'').replace(b'\n', b''))
+            
+            m = SMB2Message(SMB2CreateRequest(path,
+                                              file_attributes = 0,
+                                              access_mask = FILE_WRITE_ATTRIBUTES,
+                                              share_access = FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                              oplock = SMB2_OPLOCK_LEVEL_NONE,
+                                              impersonation = SEC_IMPERSONATE,
+                                              create_options = 0,
+                                              create_disp = FILE_OPEN,
+                                              create_context_data = create_context_data))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, createCB, errback, tid = tid)
+            self._pushToArray(messages_history, m)
+        
+        def createCB(open_message, **kwargs):
+            self._pushToArray(messages_history, open_message)
+            if open_message.status == 0:
+                sendSet(kwargs['tid'], open_message.payload.fid)
+            else:
+                errback(OperationFailure('Failed to set mtime of %s on %s: Unable to open file' % ( path, service_name ), messages_history))
+        
+        def sendSet(tid, fid):
+            m = SMB2Message(SMB2SetInfoRequest(fid,
+                                               additional_info = 0,
+                                               info_type = SMB2_INFO_FILE,
+                                               file_info_class = 4,  # FileBasicInformation
+                                               data = struct.pack('qqqqii', 0, 0, convertEpochToFILETIME(last_write_time), 0, 0, 0)))
+            # [MS-SMB2]: 2.2.39, [MS-FSCC]: 2.4, [MS-FSCC]: 2.4.7, [MS-FSCC]: 2.6
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, setCB, errback, tid = tid, fid = fid)
+            self._pushToArray(messages_history, m)
+        
+        def setCB(set_message, **kwargs):
+            self._pushToArray(messages_history, set_message)
+            if set_message.status == 0:
+                closeFid(kwargs['tid'], kwargs['fid'], status = 0)
+            else:
+                closeFid(kwargs['tid'], kwargs['fid'], status = set_message.status)
+        
+        def closeFid(tid, fid, status = None):
+            m = SMB2Message(SMB2CloseRequest(fid))
+            m.tid = tid
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, int(time.time()) + timeout, closeCB, errback, status = status)
+            self._pushToArray(messages_history, m)
+        
+        def closeCB(close_message, **kwargs):
+            if kwargs['status'] == 0:
+                callback(path)
+            else:
+                errback(OperationFailure('Failed to set mtime of %s on %s: Operation failed' % ( path, service_name ), messages_history))
+        
+        if service_name not in self.connected_trees:
+            def connectCB(connect_message, **kwargs):
+                self._pushToArray(messages_history, connect_message)
+                if connect_message.status == 0:
+                    self.connected_trees[service_name] = connect_message.tid
+                    sendCreate(connect_message.tid)
+                else:
+                    errback(OperationFailure('Failed to set mtime of %s on %s: Unable to connect to shared device' % ( path, service_name ), messages_history))
+            
+            m = SMB2Message(SMB2TreeConnectRequest(r'\\%s\%s' % ( self.remote_name.upper(), service_name )))
+            self._sendSMBMessage(m)
+            self.pending_requests[m.mid] = _PendingRequest(m.mid, expiry_time, connectCB, errback, path = service_name)
+            self._pushToArray(messages_history, m)
+        else:
+            sendCreate(self.connected_trees[service_name])
+    
     def _createDirectory_SMB2(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:
             raise NotReadyError('SMB connection not authenticated')
@@ -2763,7 +2856,10 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
 
     def _resetFileAttributes_SMB1(self, service_name, path_file_pattern, callback, errback, file_attributes=ATTR_NORMAL, timeout = 30):
         raise NotReadyError('resetFileAttributes is not yet implemented for SMB1')
-
+    
+    def _setLastWriteTime_SMB1(self, service_name, path, callback, errback, last_write_time, timeout = 30):
+        raise NotReadyError('setLastWriteTime is not yet implemented for SMB1')
+    
     def _createDirectory_SMB1(self, service_name, path, callback, errback, timeout = 30):
         if not self.has_authenticated:
             raise NotReadyError('SMB connection not authenticated')

--- a/python3/smb/utils/__init__.py
+++ b/python3/smb/utils/__init__.py
@@ -1,3 +1,6 @@
 
 def convertFILETIMEtoEpoch(t):
     return (t - 116444736000000000) / 10000000.0;
+
+def convertEpochToFILETIME(t):
+    return int(t * 10000000.0) + 116444736000000000

--- a/python3/tests/SMBConnectionTests/test_set_last_write_time.py
+++ b/python3/tests/SMBConnectionTests/test_set_last_write_time.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from nose2.tools.decorators import with_setup, with_teardown
+from smb.SMBConnection import SMBConnection
+from smb.smb_constants import *
+from smb import smb_structs
+from .util import getConnectionInfo
+
+conn = None
+
+def setup_func_SMB1():
+    global conn
+    smb_structs.SUPPORT_SMB2 = False
+    info = getConnectionInfo()
+    conn = SMBConnection(info['user'], info['password'], info['client_name'], info['server_name'], use_ntlm_v2 = True)
+    assert conn.connect(info['server_ip'], info['server_port'])
+
+def setup_func_SMB2():
+    global conn
+    smb_structs.SUPPORT_SMB2 = True
+    info = getConnectionInfo()
+    conn = SMBConnection(info['user'], info['password'], info['client_name'], info['server_name'], use_ntlm_v2 = True)
+    assert conn.connect(info['server_ip'], info['server_port'])
+
+def teardown_func():
+    global conn
+    conn.close()
+
+
+# FIXME: Disabled because setLastWriteTime is not implemented for SMB1
+# @with_setup(setup_func_SMB1)
+# @with_teardown(teardown_func)
+# def test_setLastWriteTime_SMB1():
+#     global conn
+#     conn.setLastWriteTime('smbtest', 'rfc1001.txt', 1777000000)
+#     result = conn.getAttributes('smbtest', 'rfc1001.txt')
+#     assert result.last_write_time == 1777000000
+
+@with_setup(setup_func_SMB2)
+@with_teardown(teardown_func)
+def test_setLastWriteTime_SMB2():
+    global conn
+    # Time: 2026-04-24 03:06:40 GMT
+    conn.setLastWriteTime('smbtest', 'rfc1001.txt', 1777000000)
+    result = conn.getAttributes('smbtest', 'rfc1001.txt')
+    assert result.last_write_time == 1777000000


### PR DESCRIPTION
This is primally useful for preserving modification times when copiyng files. Modification time describes a file content, rather than a file entry on a disk. Can be very helpful for backup algorithms.

Partly implemented issue #65
Tested with Samba server on Ubuntu 22.04