### PR TITLE
Fix #234: SMB._listPath_SMB1 to honor negotiated max_buffer_size

### DIFF
--- a/python3/smb/base.py
+++ b/python3/smb/base.py
@@ -2287,8 +2287,10 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
             else:
                 params_bytes += (path + pattern + '\0').encode('UTF-16LE')
 
+            # [MS-SMB] 2.2.4.5.2.2: The total SMB message size (inclusive of SMB header) must be not exceed the max_buffer_size.
+            max_data_count = min(self.max_buffer_size - 64, 0xFFFF - 64)
             m = SMBMessage(ComTransaction2Request(max_params_count = 10,
-                                                  max_data_count = 16644,
+                                                  max_data_count = max_data_count,
                                                   max_setup_count = 0,
                                                   params_bytes = params_bytes,
                                                   setup_bytes = setup_bytes))
@@ -2389,8 +2391,10 @@ c8 4f 32 4b 70 16 d3 01 12 78 5a 47 bf 6e e1 88
                             0x0006)     # Flags: SMB_FIND_RETURN_RESUME_KEYS | SMB_FIND_CLOSE_AT_EOS
             params_bytes += (resume_file+'\0').encode('UTF-16LE')
 
+            # [MS-SMB] 2.2.4.5.2.2: The total SMB message size (inclusive of SMB header) must be not exceed the max_buffer_size.
+            max_data_count = min(self.max_buffer_size - 64, 0xFFFF - 64)
             m = SMBMessage(ComTransaction2Request(max_params_count = 10,
-                                                  max_data_count = 16644,
+                                                  max_data_count = max_data_count,
                                                   max_setup_count = 0,
                                                   params_bytes = params_bytes,
                                                   setup_bytes = setup_bytes))


### PR DESCRIPTION
Fix of the issue #234

Fix SMB1 listPath() to respect the negotiated max_buffer_size when setting max_data_count for TRANS2_FIND_FIRST2 and TRANS2_FIND_NEXT2 requests. This replaces the hardcoded value (16644) with the same negotiated-buffer clamp already used by storeFile(), preventing connection resets on SMB1 servers that advertise smaller buffer sizes while maintaining protocol compliance. Verified against affected SMB1-only embedded servers.